### PR TITLE
Add return labels and credit card returns

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
     "vtex.react-portal": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.device-detector": "0.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.easypost": "0.x"
   },
   "builders": {
     "admin": "0.x",

--- a/react/common/templates/oms-return-request.html
+++ b/react/common/templates/oms-return-request.html
@@ -207,6 +207,15 @@
 
                 <tr style="box-sizing: border-box !important;">
                     <td class="ph4-ns"
+                        style="font-size: 14px; line-height: 20px; box-sizing: border-box; border-collapse: collapse; text-align: left; border-top-style: solid; border-top-width: 1px; border-bottom-style: solid; border-bottom-width: 1px; border-color: #eee; border-width: .5rem; width: 100%; padding-top: 2rem; padding-bottom: 2rem !important; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;" align="left">
+                        <div>
+                            <img src="{{data.returnLabel}}" alt="Return Label" width="80%">
+                        </div>
+                    </td>
+                </tr>
+
+                <tr style="box-sizing: border-box !important;">
+                    <td class="ph4-ns"
                         style="font-size: 14px; line-height: 20px; box-sizing: border-box; border-collapse: collapse; text-align: left; border-top-style: solid; border-top-width: 1px; border-bottom-style: solid; border-bottom-width: 1px; border-color: #eee; border-width: .5rem; width: 100%; padding-top: 2rem; padding-bottom: 2rem !important; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;"
                         align="left">
                         <h3 style="margin: 0; font-size: 20px; line-height: 36px; text-transform: uppercase; letter-spacing: 1.2pt; font-weight: 300; box-sizing: border-box; margin-top: 0 !important;">


### PR DESCRIPTION
### Return Labels
- Added return label functionality through integration with Easypost
- The Easypost app (found at [https://github.com/vtex-apps/easypost](url)) must be installed in the workspace. Make sure to fill out the client key and return address fields in the Admin page

### Credit Card Refunds
- Added ability to process returns from orders using a credit card as payment
- Refund invoice will be automatically generated when the status of a refund request is set to `refunded`

Formatting was also changed to the VTEX standard