### PR TITLE
[USAAPPTEAM-32] Show orders only if they haven't been returned

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add validation to remove orders that have already been returned through the OMS
 
 ### Added
 

--- a/node/package.json
+++ b/node/package.json
@@ -3,7 +3,7 @@
     "axios": "^0.20.0",
     "co-body": "^6.0.0",
     "ramda": "^0.25.0",
-    "@vtex/api": "6.45.3",
+    "@vtex/api": "6.45.4",
     "@vtex/clients": "^2.13.0"
   },
   "devDependencies": {
@@ -11,7 +11,7 @@
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.3",
+    "@vtex/api": "6.45.4",
     "@vtex/test-tools": "^1.0.0",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1532,10 +1532,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/api@6.45.3":
-  version "6.45.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.3.tgz#fe7d08adb4eab1fda5e34143cc6302a4c5aa5f52"
-  integrity sha512-kiD7We1TCKDyBdpYoh2Se3An+jTJRUzXGNpKifoDZylWQ1PyIx+3oL5ZAif9InlY3uJkfEisSAI6nxoKTgvPfw==
+"@vtex/api@6.45.4":
+  version "6.45.4"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.4.tgz#58be7497c0c0f91a388fabd42149e48cb95e271d"
+  integrity sha512-DVAJr5BkSjXupjn2h5Z1In8C3Li9kZwCXPwRQbpIgyS7s9dN2ZEFQc6nQlJm6ZoDCoyYBg62LgD7Kurvz9jc3w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/store/MyReturnsPageAdd.tsx
+++ b/react/store/MyReturnsPageAdd.tsx
@@ -395,9 +395,11 @@ class MyReturnsPageAdd extends Component<any, State> {
             if ('list' in orders) {
               if (orders.list.length) {
                 orders.list.forEach((order: any) => {
-                  this.getOrder(order.orderId).then((currentOrder) => {
-                    this.prepareOrderData(currentOrder, settings, true)
-                  })
+                  if(!order.invoiceInput) {
+                    this.getOrder(order.orderId).then((currentOrder) => {
+                      this.prepareOrderData(currentOrder, settings, true)
+                    })
+                  }
                 })
                 setTimeout(() => {
                   this.setState({ loading: false })


### PR DESCRIPTION
## Description
- Currently when an order is being returned through the OMS it can also be returned through the RMA

## Changes made:
- Only show show orders that have not been returned through the OMS and also orders that haven't been requested for return
- `order.invoiceInput`, is available only if the order has already been returned. 

