### PR TITLE
Atomicity request save

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -65,6 +65,7 @@ export const SETTINGS_SCHEMA = {
     'options',
     'type',
   ],
+  'v-immediate-indexing': true,
 }
 
 export const RETURNS_SCHEMA = {
@@ -124,6 +125,7 @@ export const RETURNS_SCHEMA = {
     publicJsonSchema: false,
   },
   'v-cache': false,
+  'v-immediate-indexing': true,
   'v-default-fields': [
     'id',
     'createdIn',
@@ -229,6 +231,7 @@ export const COMMENTS_SCHEMA = {
     'dateSubmitted',
     'type',
   ],
+  'v-immediate-indexing': true,
 }
 
 export const PRODUCTS_SCHEMA = {
@@ -284,6 +287,7 @@ export const PRODUCTS_SCHEMA = {
     ],
     publicJsonSchema: false,
   },
+  'v-immediate-indexing': true,
   'v-cache': false,
   'v-default-fields': [
     'id',
@@ -344,6 +348,7 @@ export const HISTORY_SCHEMA = {
     ],
     publicJsonSchema: false,
   },
+  'v-immediate-indexing': true,
   'v-cache': false,
   'v-default-fields': [
     'id',

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  doNotCall: Boolean
+}
+
+type Mutation {
+  deleteReturnRequest(Id: [ID]!): Boolean
+}

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,8 @@
     "messages": "1.x",
     "docs": "0.x",
     "store": "0.x",
-    "node": "6.x"
+    "node": "6.x",
+    "graphql": "1.x"
   },
   "scripts": {
     "postreleasy": "vtex publish --verbose"

--- a/node/index.ts
+++ b/node/index.ts
@@ -24,6 +24,7 @@ import { changeProductStatus } from './middlewares/api/changeProductStatus'
 import { checkStatus } from './middlewares/api/checkStatus'
 import { updateStatus } from './middlewares/api/updateStatus'
 import { createRefund } from './middlewares/createRefund'
+import { mutations } from './resolvers'
 
 const TIMEOUT_MS = 5000
 const memoryCache = new LRUCache<string, any>({ max: 5000 })
@@ -116,5 +117,12 @@ export default new Service({
     createRefund: method({
       POST: createRefund,
     }),
+  },
+  graphql: {
+    resolvers: {
+      Mutation: {
+        ...mutations,
+      },
+    },
   },
 })

--- a/node/package.json
+++ b/node/package.json
@@ -17,19 +17,19 @@
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.easypost": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.easypost@0.1.1/public/@types/vtex.easypost",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
-    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.22.0/public/@types/vtex.my-account",
+    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.react-portal": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.session-client": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.1/public/@types/vtex.store",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.154.0/public/@types/vtex.store-components",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.146.2/public/@types/vtex.store-graphql",
+    "vtex.return-app": "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app",
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components",
+    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
     "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources",
     "vtex.store-session": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide",
-    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.2/public/@types/vtex.telemarketing"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide",
+    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing"
   },
   "scripts": {
     "lint": "tsc --noEmit --pretty && tslint -c tslint.json --fix './**/*.ts'"

--- a/node/package.json
+++ b/node/package.json
@@ -21,7 +21,7 @@
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.react-portal": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app",
+    "vtex.return-app": "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644361871/public/@types/vtex.return-app",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql",

--- a/node/resolvers/deleteReturnRequest.ts
+++ b/node/resolvers/deleteReturnRequest.ts
@@ -1,0 +1,21 @@
+export const deleteReturnRequest = async (
+  _: unknown,
+  args: { Id: string[] },
+  ctx: Context
+) => {
+  const { Id } = args
+  const {
+    clients: { masterdata },
+  } = ctx
+
+  const promises = Id.map((id) => {
+    return masterdata.deleteDocument({ id, dataEntity: 'ReturnApp' })
+  })
+
+  await Promise.all(promises)
+
+  // Hard coded data entity name. Later, we should take it to a constant file.
+  // Not doing now to avoid confusion with other constant files
+
+  return true
+}

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,0 +1,3 @@
+import { deleteReturnRequest } from './deleteReturnRequest'
+
+export const mutations = { deleteReturnRequest }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5539,7 +5539,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -6008,9 +6008,9 @@ verror@1.10.0:
   version "1.6.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons#3715228fb82e81e955e6a90d11e7975e72b37b2e"
 
-"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.22.0/public/@types/vtex.my-account":
-  version "1.22.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.22.0/public/@types/vtex.my-account#d3ca631dd45c2bebb938239ff912125ad7c09c4c"
+"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account":
+  version "1.24.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account#f1dfdcedd359e5716d30f4765181bd52a90b37d8"
 
 "vtex.react-portal@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal":
   version "0.4.1"
@@ -6020,17 +6020,17 @@ verror@1.10.0:
   version "8.132.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
-"vtex.session-client@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client":
-  version "1.0.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client#239ac9935a59699e62e1509f844de81544ed0877"
+"vtex.return-app@https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app":
+  version "2.16.1"
+  resolved "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app#b671ad077d00616e8eeb9b4df93681a33ce3e82e"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.154.0/public/@types/vtex.store-components":
-  version "3.154.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.154.0/public/@types/vtex.store-components#f90710aad97452e330a44ecc6738aa8b8110130a"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components":
+  version "3.155.9"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components#3dc767937110f31a859765e7ec21a85654151622"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.146.2/public/@types/vtex.store-graphql":
-  version "2.146.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.146.2/public/@types/vtex.store-graphql#056b6350a6b81f4dc92e83f2739f4825afd7f896"
+"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql":
+  version "2.149.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql#f0d8a098e77875e69e5ef01453ba5e76de44e4f1"
 
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons":
   version "0.18.0"
@@ -6044,17 +6044,17 @@ verror@1.10.0:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.1/public/@types/vtex.store":
-  version "2.120.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.1/public/@types/vtex.store#fda1d0c7a0226d7229a51a81ec3721bf23d5aa6e"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store":
+  version "2.121.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store#1401d6ee5e16ff8b52227213f05331bba94a5639"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide":
-  version "9.145.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide#41dfb32af8756eb5528dbd452e47003a8f67fe8c"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide":
+  version "9.145.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide#ca64bf8408ad3eb487b0822dd68f77565c986a56"
 
-"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.2/public/@types/vtex.telemarketing":
-  version "2.10.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.2/public/@types/vtex.telemarketing#618f97a1cc0af09b5809cf2f4561cc19b9189cef"
+"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing":
+  version "2.10.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing#13f962450036d2e8d6cf79784e55d2bf418823e0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6020,9 +6020,9 @@ verror@1.10.0:
   version "8.132.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
-"vtex.return-app@https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app":
+"vtex.return-app@https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644361871/public/@types/vtex.return-app":
   version "2.16.1"
-  resolved "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app#b671ad077d00616e8eeb9b4df93681a33ce3e82e"
+  resolved "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644361871/public/@types/vtex.return-app#4639f212b905646d6614be9a44e0ee8ab832d9b6"
 
 "vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components":
   version "3.155.9"

--- a/react/package.json
+++ b/react/package.json
@@ -36,7 +36,7 @@
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.react-portal": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app",
+    "vtex.return-app": "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644361612/public/@types/vtex.return-app",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql",

--- a/react/package.json
+++ b/react/package.json
@@ -32,19 +32,19 @@
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.easypost": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.easypost@0.1.1/public/@types/vtex.easypost",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
-    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.22.0/public/@types/vtex.my-account",
+    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.react-portal": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.session-client": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.1/public/@types/vtex.store",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.154.0/public/@types/vtex.store-components",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.146.2/public/@types/vtex.store-graphql",
+    "vtex.return-app": "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app",
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components",
+    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
     "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources",
     "vtex.store-session": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide",
-    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.2/public/@types/vtex.telemarketing"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide",
+    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing"
   },
   "version": "2.16.1"
 }

--- a/react/store/MyReturnsPageAdd.tsx
+++ b/react/store/MyReturnsPageAdd.tsx
@@ -817,8 +817,7 @@ class MyReturnsPageAdd extends Component<any, State> {
 
       if ('DocumentId' in response) {
         requestId = response.DocumentId
-        console.log(requestId, 'req id')
-        console.log(typeof requestId, 'typeee')
+
         await this.addStatusHistory(requestId)
         const productsResponse = await this.submitProductRequest(requestId)
 
@@ -826,7 +825,6 @@ class MyReturnsPageAdd extends Component<any, State> {
           deleteIdsArg = [requestId, ...productsResponse]
         }
 
-        console.log(productsResponse, 'productsResponse')
         throw new Error()
 
         this.setState({
@@ -844,14 +842,12 @@ class MyReturnsPageAdd extends Component<any, State> {
         throw new Error()
       }
     } catch (e) {
-      console.log(deleteIdsArg, 'deleteIdsArg')
       await this.props.deleteReturnRequest({ variables: { Id: deleteIdsArg } })
       console.error({ e })
       this.setState({
         errorSubmit: formatMessage({ id: messages.submitError.id }),
         submittedRequest: true,
       })
-      console.log('been here')
     }
   }
 
@@ -908,7 +904,6 @@ class MyReturnsPageAdd extends Component<any, State> {
           type: schemaTypes.products,
         }
 
-        console.log({ productData })
         try {
           // eslint-disable-next-line no-await-in-loop
           const resSingleProd = await this.sendData(
@@ -917,7 +912,6 @@ class MyReturnsPageAdd extends Component<any, State> {
           )
 
           indexes.push(resSingleProd.DocumentId)
-          console.log(resSingleProd, 'Refund id? from res')
         } catch (e) {
           console.error(e)
         }

--- a/react/store/graphql/deleteReturnRequest.gql
+++ b/react/store/graphql/deleteReturnRequest.gql
@@ -1,0 +1,3 @@
+mutation deleteReturnRequest($Id: [ID]!) {
+  deleteReturnRequest(Id: $Id) @context(provider: "vtex.return-app")
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5020,9 +5020,9 @@ verror@1.10.0:
   version "8.132.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
-"vtex.return-app@https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app":
+"vtex.return-app@https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644361612/public/@types/vtex.return-app":
   version "2.16.1"
-  resolved "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app#b671ad077d00616e8eeb9b4df93681a33ce3e82e"
+  resolved "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644361612/public/@types/vtex.return-app#c93813aadb6ca3dd4759a94b146ea6ae08688036"
 
 "vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components":
   version "3.155.9"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5008,9 +5008,9 @@ verror@1.10.0:
   version "1.6.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons#3715228fb82e81e955e6a90d11e7975e72b37b2e"
 
-"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.22.0/public/@types/vtex.my-account":
-  version "1.22.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.22.0/public/@types/vtex.my-account#d3ca631dd45c2bebb938239ff912125ad7c09c4c"
+"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account":
+  version "1.24.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account#f1dfdcedd359e5716d30f4765181bd52a90b37d8"
 
 "vtex.react-portal@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal":
   version "0.4.1"
@@ -5020,17 +5020,17 @@ verror@1.10.0:
   version "8.132.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
-"vtex.session-client@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client":
-  version "1.0.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.session-client@1.0.2/public/@types/vtex.session-client#239ac9935a59699e62e1509f844de81544ed0877"
+"vtex.return-app@https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app":
+  version "2.16.1"
+  resolved "https://zeki--vtexspain.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@2.16.1+build1644336476/public/@types/vtex.return-app#b671ad077d00616e8eeb9b4df93681a33ce3e82e"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.154.0/public/@types/vtex.store-components":
-  version "3.154.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.154.0/public/@types/vtex.store-components#f90710aad97452e330a44ecc6738aa8b8110130a"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components":
+  version "3.155.9"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components#3dc767937110f31a859765e7ec21a85654151622"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.146.2/public/@types/vtex.store-graphql":
-  version "2.146.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.146.2/public/@types/vtex.store-graphql#056b6350a6b81f4dc92e83f2739f4825afd7f896"
+"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql":
+  version "2.149.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql#f0d8a098e77875e69e5ef01453ba5e76de44e4f1"
 
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons":
   version "0.18.0"
@@ -5044,17 +5044,17 @@ verror@1.10.0:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.1/public/@types/vtex.store":
-  version "2.120.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.1/public/@types/vtex.store#fda1d0c7a0226d7229a51a81ec3721bf23d5aa6e"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store":
+  version "2.121.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store#1401d6ee5e16ff8b52227213f05331bba94a5639"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide":
-  version "9.145.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide#41dfb32af8756eb5528dbd452e47003a8f67fe8c"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide":
+  version "9.145.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide#ca64bf8408ad3eb487b0822dd68f77565c986a56"
 
-"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.2/public/@types/vtex.telemarketing":
-  version "2.10.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.2/public/@types/vtex.telemarketing#618f97a1cc0af09b5809cf2f4561cc19b9189cef"
+"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing":
+  version "2.10.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing#13f962450036d2e8d6cf79784e55d2bf418823e0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
What this PR changes
In this PR we fix the behaviour of being able to create more than one return request. This happened because the documents created in masterdata were given at different times. First we generate the return request document and then the product documents one by one. 
How we solved it: if when saving a document there is an error we store all the ids of the already generated documents and proceed to delete them.


How to test it:

Workspace: [this workspace](https://zeki--powerplanet.myvtex.com/?__bindingAddress=www.we-demostore.com/es).

To test the fix, you can create an order in the mentioned workspace. After that you should move the status of the order/s until `invoiced`.
When the order has been invoiced, you can go to [My account/My returns](https://zeki--powerplanet.myvtex.com/account?__bindingAddress=www.we-demostore.com/es#/my-returns) page and make a return request. We should see an error and if we try again to create a return request the same order should be available.