### PR TITLE
Create rma graphql frontend

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ## Added
-- Graphql mutation to create a new return request. Make it atomic, deleting all objects related to it if something fails during the process
+- Graphql mutation to create a new return request. Make it atomic, deleting all objects related to it if something fails during the process.
 
 ## [2.1.0 to 2.17.0]
 ### Fixed

--- a/graphql/types/ProductReturned.graphql
+++ b/graphql/types/ProductReturned.graphql
@@ -10,6 +10,7 @@ input ProductReturnedInput {
   unitPrice: Int!
   quantity: Int!
   goodProducts: Int!
+  reason: String!
   reasonCode: String!
   condition: String!
 }
@@ -33,6 +34,7 @@ type ProductReturned {
   quantity: Int!
   totalPrice: Int!
   goodProducts: Int!
+  reason: String!
   reasonCode: String!
   condition: String!
   status: String!

--- a/node/clients/mdFactory.ts
+++ b/node/clients/mdFactory.ts
@@ -36,6 +36,10 @@ export class MDFactory extends MasterData {
     },
   }
 
+  public deleteRMADocument(id: string) {
+    return this.deleteDocument({ id, dataEntity: this.dataEntity })
+  }
+
   public searchReturnRequests({
     fields,
     pagination,

--- a/node/resolvers/createReturnRequest.ts
+++ b/node/resolvers/createReturnRequest.ts
@@ -12,7 +12,7 @@ export const createReturnRequest = async (
   ctx: Context
 ) => {
   const {
-    clients: { oms, masterdata, returnApp, mdFactory },
+    clients: { oms, returnApp, mdFactory },
     vtex: { logger },
   } = ctx
 
@@ -108,7 +108,7 @@ export const createReturnRequest = async (
     // if something fails, we delete all documents related to that request.
     // This way, we try to make the operation atomic.
     const deletedDocumentPromises = documentIdCollection.map((id) =>
-      masterdata.deleteDocument({ id, dataEntity: 'ReturnApp' })
+      mdFactory.deleteRMADocument(id)
     )
 
     await Promise.all(deletedDocumentPromises)

--- a/node/resolvers/deleteReturnRequest.ts
+++ b/node/resolvers/deleteReturnRequest.ts
@@ -5,17 +5,14 @@ export const deleteReturnRequest = async (
 ) => {
   const { Id } = args
   const {
-    clients: { masterdata },
+    clients: { mdFactory },
   } = ctx
 
   const promises = Id.map((id) => {
-    return masterdata.deleteDocument({ id, dataEntity: 'ReturnApp' })
+    return mdFactory.deleteRMADocument(id)
   })
 
   await Promise.all(promises)
-
-  // Hard coded data entity name. Later, we should take it to a constant file.
-  // Not doing now to avoid confusion with other constant files
 
   return true
 }

--- a/react/StoreMyReturnsPageAdd.tsx
+++ b/react/StoreMyReturnsPageAdd.tsx
@@ -1,11 +1,14 @@
 import type { FC } from 'react'
 import React, { Fragment } from 'react'
 import { Route } from 'vtex.my-account-commons/Router'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, useIntl } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
+import { useMutation } from 'react-apollo'
+import { useCssHandles } from 'vtex.css-handles'
 
 import useAxiosInstance from './hooks/useAxiosModule'
 import ReturnsPageAdd from './store/MyReturnsPageAdd'
+import CREATE_RETURN_REQUEST from './store/graphql/createReturnRequest.gql'
 
 const headerConfig = {
   namespace: 'vtex-account__returns-list',
@@ -16,9 +19,29 @@ const headerConfig = {
   },
 }
 
+const CSS_HANDLES = ['errorContainer']
+
 const StoreMyReturnsPageAddWrapper: FC = (props: any) => {
   const axios = useAxiosInstance()
-  const { production, binding } = useRuntime()
+  const { production, binding, rootPath } = useRuntime()
+  const intl = useIntl()
+  const [createReturnRequest, { error, loading, called }] = useMutation<
+    { returnRequestId: string },
+    ReturnRequestMutationArgs
+  >(CREATE_RETURN_REQUEST)
+
+  const handles = useCssHandles(CSS_HANDLES)
+
+  const sendRequest = ({
+    returnRequest,
+    returnedItems,
+  }: ReturnRequestMutationArgs) =>
+    createReturnRequest({
+      variables: {
+        returnRequest,
+        returnedItems,
+      },
+    })
 
   return (
     <ReturnsPageAdd
@@ -27,6 +50,13 @@ const StoreMyReturnsPageAddWrapper: FC = (props: any) => {
       fetchApi={axios}
       production={production}
       binding={binding}
+      rootPath={rootPath}
+      cssHandles={handles}
+      intl={intl}
+      creatReturnRequest={{
+        sendRequest,
+        data: { error, loading, called },
+      }}
     />
   )
 }

--- a/react/admin/ReturnSettingsWrapper.tsx
+++ b/react/admin/ReturnSettingsWrapper.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Layout, PageHeader } from 'vtex.styleguide'
+import { FormattedMessage } from 'react-intl'
+
+import ReturnsSettings from './ReturnsSettings'
+
+const ReturnSettingsWrapper = (props: any) => {
+  return (
+    <Layout
+      pageHeader={
+        <PageHeader
+          title={<FormattedMessage id="navigation.labelSettings" />}
+        />
+      }
+    >
+      <ReturnsSettings {...props} />
+    </Layout>
+  )
+}
+
+export default ReturnSettingsWrapper

--- a/react/store/graphql/createReturnRequest.gql
+++ b/react/store/graphql/createReturnRequest.gql
@@ -6,7 +6,7 @@ mutation CreateReturn(
     returnRequest: $returnRequest
     returnedItems: $returnedItems
     authToken: STORE_TOKEN
-  ) {
+  ) @context(provider: "vtex.return-app") {
     returnRequestId
   }
 }

--- a/react/store/graphql/createReturnRequest.gql
+++ b/react/store/graphql/createReturnRequest.gql
@@ -1,0 +1,12 @@
+mutation CreateReturn(
+  $returnRequest: ReturnRequestInput!
+  $returnedItems: [ProductReturnedInput!]!
+) {
+  createReturnRequest(
+    returnRequest: $returnRequest
+    returnedItems: $returnedItems
+    authToken: STORE_TOKEN
+  ) {
+    returnRequestId
+  }
+}

--- a/react/store/graphql/deleteReturnRequest.gql
+++ b/react/store/graphql/deleteReturnRequest.gql
@@ -1,3 +1,0 @@
-mutation deleteReturnRequest($Id: [ID]!) {
-  deleteReturnRequest(Id: $Id) @context(provider: "vtex.return-app")
-}

--- a/react/typings/vtex.return-app.d.ts
+++ b/react/typings/vtex.return-app.d.ts
@@ -77,3 +77,8 @@ type ProductReturnedInput = Omit<
   | 'totalPrice'
   | 'status'
 >
+
+interface ReturnRequestMutationArgs {
+  returnRequest: ReturnRequestInput
+  returnedItems: ProductReturnedInput[]
+}


### PR DESCRIPTION
#### What problem is this solving?

This PR connects the front end module to create an new RMA to the Graphql handling the process. It allows us to replace the several calls coming back and froth from the browser to the server the app was using before, making it prone to error.

The logic was placed in a functional wrapper component, which we can use to slowly replace the class one.

The component that needs more details in the review is: `react/store/MyReturnsPageAdd.tsx`.
The previous methods making the requests to create 1. the return request; 2. the history message; 3 the products requests; and 4. send email, were replaced by the single to to the back end using Graphql.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
Login in the store. Create a new request. All should work fine and the request will be available when you return to the main page.

The branch is linked in this [workspace](https://rmagraphqlfrontend--vtexspain.myvtex.com/)
