### PR TITLE
Update schema

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -14,4 +14,5 @@ type Mutation {
     returnedItems: [ProductReturnedInput!]!
     authToken: AuthToken!
   ): returnRequestCreated
+  createOrUpdateSchemas: Boolean
 }

--- a/node/.eslintrc
+++ b/node/.eslintrc
@@ -3,12 +3,12 @@
   "env": {
     "browser": true,
     "es6": true,
-    "jest": true
+    "jest": true,
+    "node": true
   },
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off",
     "camelcase": [1, {"properties": "always"}
     ],
-    "no-console": "off"
+    "import/no-nodejs-modules": "off"
   }
 }

--- a/node/clients/mdFactory.ts
+++ b/node/clients/mdFactory.ts
@@ -86,4 +86,79 @@ export class MDFactory extends MasterData {
       fields: productReturnFields,
     })
   }
+
+  public updateSettingsSchema(schemaBody: typeof SETTINGS_SCHEMA) {
+    return this.createOrUpdateSchema({
+      dataEntity: this.dataEntity,
+      schemaName: this.schemas.settingsSchema.name,
+      schemaBody,
+    })
+  }
+
+  public updateRequestSchema(schemaBody: typeof RETURNS_SCHEMA) {
+    return this.createOrUpdateSchema({
+      dataEntity: this.dataEntity,
+      schemaName: this.schemas.returnSchema.name,
+      schemaBody,
+    })
+  }
+
+  public updateCommentsSchema(schemaBody: typeof COMMENTS_SCHEMA) {
+    return this.createOrUpdateSchema({
+      dataEntity: this.dataEntity,
+      schemaName: this.schemas.commentsSchema.name,
+      schemaBody,
+    })
+  }
+
+  public updateHistorySchema(schemaBody: typeof HISTORY_SCHEMA) {
+    return this.createOrUpdateSchema({
+      dataEntity: this.dataEntity,
+      schemaName: this.schemas.statusHistorySchema.name,
+      schemaBody,
+    })
+  }
+
+  public updatetProductsSchema(schemaBody: typeof PRODUCTS_SCHEMA) {
+    return this.createOrUpdateSchema({
+      dataEntity: this.dataEntity,
+      schemaName: this.schemas.productsSchema.name,
+      schemaBody,
+    })
+  }
+
+  public getSettingsSchema() {
+    return this.getSchema({
+      dataEntity: this.dataEntity,
+      schema: this.schemas.settingsSchema.name,
+    })
+  }
+
+  public getRequestSchema() {
+    return this.getSchema({
+      dataEntity: this.dataEntity,
+      schema: this.schemas.returnSchema.name,
+    })
+  }
+
+  public getCommentsSchema() {
+    return this.getSchema({
+      dataEntity: this.dataEntity,
+      schema: this.schemas.commentsSchema.name,
+    })
+  }
+
+  public getHistorySchema() {
+    return this.getSchema({
+      dataEntity: this.dataEntity,
+      schema: this.schemas.statusHistorySchema.name,
+    })
+  }
+
+  public getProductsSchema() {
+    return this.getSchema({
+      dataEntity: this.dataEntity,
+      schema: this.schemas.productsSchema.name,
+    })
+  }
 }

--- a/node/resolvers/createOrUpdateSchemas.ts
+++ b/node/resolvers/createOrUpdateSchemas.ts
@@ -1,0 +1,11 @@
+import { checkAndUpdateSchemas } from '../utils/checkAndUpdateSchemas'
+
+export const createOrUpdateSchemas = async (
+  _: unknown,
+  _args: unknown,
+  ctx: Context
+) => {
+  await checkAndUpdateSchemas(ctx)
+
+  return true
+}

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,4 +1,9 @@
 import { deleteReturnRequest } from './deleteReturnRequest'
 import { createReturnRequest } from './createReturnRequest'
+import { createOrUpdateSchemas } from './createOrUpdateSchemas'
 
-export const mutations = { deleteReturnRequest, createReturnRequest }
+export const mutations = {
+  deleteReturnRequest,
+  createReturnRequest,
+  createOrUpdateSchemas,
+}

--- a/node/utils/checkAndUpdateSchemas.ts
+++ b/node/utils/checkAndUpdateSchemas.ts
@@ -30,11 +30,13 @@ const isSchemaUpdated = async (ctx: Context) => {
   return false
 }
 
-export const updateSchema = async (ctx: Context) => {
+export const checkAndUpdateSchemas = async (ctx: Context) => {
   const {
     clients: { vbase, mdFactory },
     vtex: { logger },
   } = ctx
+
+  let hasUpdated = false
 
   try {
     const updated = await isSchemaUpdated(ctx)
@@ -75,24 +77,29 @@ export const updateSchema = async (ctx: Context) => {
     if (!isDeepStrictEqual(settingsSchema, SETTINGS_SCHEMA)) {
       updateSettingsSchemaPromise =
         mdFactory.updateSettingsSchema(SETTINGS_SCHEMA)
+      hasUpdated = true
     }
 
     if (!isDeepStrictEqual(requestSchema, RETURNS_SCHEMA)) {
       updateRequestSchemaPromise = mdFactory.updateRequestSchema(RETURNS_SCHEMA)
+      hasUpdated = true
     }
 
     if (!isDeepStrictEqual(commentsSchema, COMMENTS_SCHEMA)) {
       updateCommentsSchemaPromise =
         mdFactory.updateCommentsSchema(COMMENTS_SCHEMA)
+      hasUpdated = true
     }
 
     if (!isDeepStrictEqual(historySchema, HISTORY_SCHEMA)) {
       updateHistorySchemaPromise = mdFactory.updateHistorySchema(HISTORY_SCHEMA)
+      hasUpdated = true
     }
 
     if (!isDeepStrictEqual(productsSchema, PRODUCTS_SCHEMA)) {
       updateProductsSchemaPromise =
         mdFactory.updatetProductsSchema(PRODUCTS_SCHEMA)
+      hasUpdated = true
     }
 
     await Promise.all([
@@ -113,7 +120,13 @@ export const updateSchema = async (ctx: Context) => {
     }
   }
 
-  logger.info({
-    message: `Schemas updated, appVersion: ${appVersion}`,
-  })
+  if (hasUpdated) {
+    logger.info({
+      message: `Schemas updated, appVersion: ${appVersion}`,
+    })
+  } else {
+    logger.info({
+      message: `Schemas checked. Nothing to update, appVersion: ${appVersion}`,
+    })
+  }
 }

--- a/node/utils/updateSchema.ts
+++ b/node/utils/updateSchema.ts
@@ -1,0 +1,119 @@
+import { isDeepStrictEqual } from 'util'
+
+import { LINKED } from '@vtex/api'
+
+import {
+  COMMENTS_SCHEMA,
+  HISTORY_SCHEMA,
+  PRODUCTS_SCHEMA,
+  RETURNS_SCHEMA,
+  SETTINGS_SCHEMA,
+} from '../../common/constants'
+
+const appVersion = process.env.VTEX_APP_VERSION as string
+const BUCKET_NAME = 'rma-schemaUpdated'
+
+const isSchemaUpdated = async (ctx: Context) => {
+  if (LINKED) return false
+  const {
+    clients: { vbase },
+  } = ctx
+
+  const wasUpdated = await vbase.getJSON<boolean | null>(
+    BUCKET_NAME,
+    appVersion,
+    true
+  )
+
+  if (wasUpdated) return true
+
+  return false
+}
+
+export const updateSchema = async (ctx: Context) => {
+  const {
+    clients: { vbase, mdFactory },
+    vtex: { logger },
+  } = ctx
+
+  try {
+    const updated = await isSchemaUpdated(ctx)
+
+    // if updated === true, we don't need to update the schema
+    if (updated) return
+
+    // we update vbase no matter the result of hasChanged, so next call we skip the check
+    await vbase.saveJSON(BUCKET_NAME, appVersion, 'true')
+
+    // if hasChanged === false, we don't need to update the schema
+    const settingsSchemaPromise = mdFactory.getSettingsSchema()
+    const requestSchemaPromise = mdFactory.getRequestSchema()
+    const commentsSchemaPromise = mdFactory.getCommentsSchema()
+    const historySchemaPomise = mdFactory.getHistorySchema()
+    const productsSchemaPromise = mdFactory.getProductsSchema()
+
+    const [
+      settingsSchema,
+      requestSchema,
+      commentsSchema,
+      historySchema,
+      productsSchema,
+    ] = await Promise.all([
+      settingsSchemaPromise,
+      requestSchemaPromise,
+      commentsSchemaPromise,
+      historySchemaPomise,
+      productsSchemaPromise,
+    ])
+
+    let updateSettingsSchemaPromise
+    let updateRequestSchemaPromise
+    let updateCommentsSchemaPromise
+    let updateHistorySchemaPromise
+    let updateProductsSchemaPromise
+
+    if (!isDeepStrictEqual(settingsSchema, SETTINGS_SCHEMA)) {
+      updateSettingsSchemaPromise =
+        mdFactory.updateSettingsSchema(SETTINGS_SCHEMA)
+    }
+
+    if (!isDeepStrictEqual(requestSchema, RETURNS_SCHEMA)) {
+      updateRequestSchemaPromise = mdFactory.updateRequestSchema(RETURNS_SCHEMA)
+    }
+
+    if (!isDeepStrictEqual(commentsSchema, COMMENTS_SCHEMA)) {
+      updateCommentsSchemaPromise =
+        mdFactory.updateCommentsSchema(COMMENTS_SCHEMA)
+    }
+
+    if (!isDeepStrictEqual(historySchema, HISTORY_SCHEMA)) {
+      updateHistorySchemaPromise = mdFactory.updateHistorySchema(HISTORY_SCHEMA)
+    }
+
+    if (!isDeepStrictEqual(productsSchema, PRODUCTS_SCHEMA)) {
+      updateProductsSchemaPromise =
+        mdFactory.updatetProductsSchema(PRODUCTS_SCHEMA)
+    }
+
+    await Promise.all([
+      updateSettingsSchemaPromise,
+      updateRequestSchemaPromise,
+      updateCommentsSchemaPromise,
+      updateHistorySchemaPromise,
+      updateProductsSchemaPromise,
+    ])
+  } catch (error) {
+    if (error.response.status !== 304) {
+      logger.error({
+        message: `Error updating schema, appVersion: ${appVersion}`,
+        error,
+      })
+
+      return
+    }
+  }
+
+  logger.info({
+    message: `Schemas updated, appVersion: ${appVersion}`,
+  })
+}


### PR DESCRIPTION
This a draft PR so we can discuss the approach to update schemas.

### Current Problem
For every change in the schema, a store admin needs to go to the settings page in order to trigger the schema update. If they don't that, it can lead to problems when saving and searching documents.

The current process is the following:
1. The app checks the schema when the component for the Admin Settings renders [here](https://github.com/vtex-apps/return-app/blob/1bef8ee0be84fcf14b29f81df5a4f1a435be05a3/react/admin/ReturnsSettings.tsx#L206);
2. The browser fetches all the schemas, and compare every one with its pair in the code [here](https://github.com/vtex-apps/return-app/blob/1bef8ee0be84fcf14b29f81df5a4f1a435be05a3/react/common/utils.tsx#L582);
3. Then, the browsers call the back end, that will update all the schemas [here](https://github.com/vtex-apps/return-app/blob/1bef8ee0be/node/clients/masterdata.ts#L57-L124).

### My suggestion
Devise a logic all in the back end to trigger the schema update and place it in key processes, like when __store users are creating new orders__ AND the __admin visits the settings page__. 

The new function on `node/utils/checkAndUpdateSchemas.ts` can be called inside any resolver and handles all the logic.

The decision process is the following:

[![](https://mermaid.ink/img/pako:eNpVkV9rgzAUxb_KJU8rtF_Ah5VNrXWDvnQrjOhDMNcaqokkcVDU7774j6nkQfI75-TkpiWZ4kg8ctesLuArSCS4762NDbC6hlLIB_JjP2_D4fAK3Q-aDnx6URa4kphu4EV1EFC_wOwBt3dmFhyMOGxvqI1QEpqaM_sfHa6iTy-Bi91twBDr0-_RBL9zhlvrI_xRGtEILZiswIqZmUQjOVNfVTXTCNcNPTsKJ6UBXfBzto6OeJjDJAYu8hw1SrtUjleVP5ZqkzjdKIbun3S4U0r2pEJdMcHdzNtBlRDrHJgQz_1yzFlT2oQksnfSaUYhF1Zp4uWsNLgnrLHq-pQZ8axucBEFgrknrGZV_wchQJQq)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpVkV9rgzAUxb_KJU8rtF_Ah5VNrXWDvnQrjOhDMNcaqokkcVDU7774j6nkQfI75-TkpiWZ4kg8ctesLuArSCS4762NDbC6hlLIB_JjP2_D4fAK3Q-aDnx6URa4kphu4EV1EFC_wOwBt3dmFhyMOGxvqI1QEpqaM_sfHa6iTy-Bi91twBDr0-_RBL9zhlvrI_xRGtEILZiswIqZmUQjOVNfVTXTCNcNPTsKJ6UBXfBzto6OeJjDJAYu8hw1SrtUjleVP5ZqkzjdKIbun3S4U0r2pEJdMcHdzNtBlRDrHJgQz_1yzFlT2oQksnfSaUYhF1Zp4uWsNLgnrLHq-pQZ8axucBEFgrknrGZV_wchQJQq)

### How to test the function

In this [workspace](https://fila--vtexspain.myvtex.com/_v/private/vtex.return-app@2.17.0/graphiql/v1?query=mutation%20%7B%0A%20%20createOrUpdateSchemas%0A%7D), one can trigger the function.

To see the effects, update any of the schema using Postman. Run the mutation, then check the schema on postman. It should be updated back to the original version.

Update the schema - missing field `skuId` inside `v-indexed`:
```curl
curl --location --request PUT 'https://vtexspain.vtexcommercestable.com.br/api/dataentities/ReturnApp/schemas/returnProducts' \
--header 'VtexIdclientAutCookie: {{authToken}}' \
--header 'Content-Type: application/json' \
--data-raw '{
    "properties": {
        "refundId": {
            "type": "string",
            "IsRelationship": true
        },
        "orderId": {
            "type": "string",
            "IsRelationship": true
        },
        "userId": {
            "type": "string",
            "IsRelationship": true
        },
        "imageUrl": {
            "type": "string"
        },
        "skuId": {
            "type": "string"
        },
        "sku": {
            "type": "string"
        },
        "productId": {
            "type": "string"
        },
        "ean": {
            "type": "string"
        },
        "brandId": {
            "type": "string"
        },
        "brandName": {
            "type": "string"
        },
        "skuName": {
            "type": "string"
        },
        "manufacturerCode": {
            "type": "string"
        },
        "unitPrice": {
            "type": "integer"
        },
        "quantity": {
            "type": "integer"
        },
        "totalPrice": {
            "type": "integer"
        },
        "goodProducts": {
            "type": "integer"
        },
        "reasonCode": {
            "type": "string"
        },
        "reason": {
            "type": "string"
        },
        "condition": {
            "type": "string"
        },
        "status": {
            "type": "string"
        },
        "dateSubmitted": {
            "type": "string",
            "format": "date-time"
        },
        "type": {
            "type": "string"
        }
    },
    "v-security": {
        "allowGetAll": true,
        "publicFilter": [
            "refundId",
            "orderId",
            "userId",
            "imageUrl",
            "skuId",
            "sku",
            "productId",
            "ean",
            "brandId",
            "brandName",
            "skuName",
            "manufacturerCode",
            "unitPrice",
            "quantity",
            "totalPrice",
            "goodProducts",
            "reasonCode",
            "reason",
            "condition",
            "status",
            "dateSubmitted",
            "type"
        ],
        "publicJsonSchema": false
    },
    "v-immediate-indexing": true,
    "v-cache": false,
    "v-default-fields": [
        "id",
        "createdIn",
        "refundId",
        "orderId",
        "userId",
        "imageUrl",
        "sku",
        "skuId",
        "productId",
        "ean",
        "brandId",
        "brandName",
        "skuName",
        "manufacturerCode",
        "unitPrice",
        "quantity",
        "totalPrice",
        "goodProducts",
        "reasonCode",
        "reason",
        "condition",
        "status",
        "dateSubmitted",
        "type"
    ],
    "v-indexed": [
        "id",
        "createdIn",
        "refundId",
        "orderId",
        "userId",
        "sku",
        "skuName",
        "status",
        "type"
    ]
}'
```
Get the schema - field `skuId` inside `v-indexed` should be back.

```curl
curl --location --request GET 'https://vtexspain.vtexcommercestable.com.br/api/dataentities/ReturnApp/schemas/returnProducts' \
--header 'VtexIdclientAutCookie: {{authToken}}' 
```