### PR TITLE
Fix error 403 when creating a new request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `createReturnRequest` throwing a 403 due to wrong auth cookies passed to get order details.
 
 ## [2.18.1] - 2022-02-21
 ### Fixed
@@ -22,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Request to create a new RMA is now using Graphql mutation `createReturnRequest`.
 - RMA sequence number is created using the order sequence number.
 
-### Fix
+### Fixed
 - Total products value on return request details page in the Admin side. It was being divided by 100.
 
 ## [2.1.0 to 2.17.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.18.2] - 2022-02-22
 ### Fixed
 - `createReturnRequest` throwing a 403 due to wrong auth cookies passed to get order details.
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,6 +1,7 @@
 enum AuthToken {
   ADMIN_TOKEN
   STORE_TOKEN
+  AUTH_TOKEN
 }
 
 type Query {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "return-app",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "title": "Return app",
   "description": "Return app",
   "dependencies": {

--- a/react/store/graphql/createReturnRequest.gql
+++ b/react/store/graphql/createReturnRequest.gql
@@ -5,7 +5,7 @@ mutation CreateReturn(
   createReturnRequest(
     returnRequest: $returnRequest
     returnedItems: $returnedItems
-    authToken: STORE_TOKEN
+    authToken: AUTH_TOKEN
   ) @context(provider: "vtex.return-app") {
     returnRequestId
   }


### PR DESCRIPTION
This PR fixes the error preventing users using a non-VTEX email to create a return request. The error was due to a request to get the order information. The app was passing `STORE_TOKEN` to the request. Changing to `AUTH_TOKEN` fixed the problem.

A new version was already released `v2.18.2` and it's install on powerplanet. It can be tested here: https://www.we-demostore.com/es