### PR TITLE
Fix: Add refundId to returnRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- add `refundId` to returnRequests schema 
+
 
 ## [2.18.2] - 2022-02-22
 ### Fixed

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -75,6 +75,9 @@ export const SETTINGS_SCHEMA = {
 export const RETURNS_SCHEMA = {
   properties: {
     userId: { type: 'string', IsRelationship: true },
+    refundId: {
+      type: ['string', 'null'],
+    },
     orderId: { type: 'string', IsRelationship: true },
     name: { type: 'string' },
     email: { type: 'string', format: 'email' },
@@ -161,6 +164,7 @@ export const RETURNS_SCHEMA = {
   ],
   'v-indexed': [
     'id',
+    'refundId',
     'createdIn',
     'userId',
     'orderId',


### PR DESCRIPTION
#### What problem is this solving?

In admin section where users can view and set the "Returns List" table
Returns page has list of items that the customers want to return, when click on the square icon beside each item to view its history it was not working as expected, so this fix is to indexation `refundId` in `returnRequests` schema.

**Admin**
Go to Applications, from `Returns` section select `Request` there you will find a list of all items that all the client users wanted to return so you can use this [link](https://returnhistory--yamamayqa.myvtex.com/admin/returns/requests/) to test click on any one of the item either on square or the eye icon to view the history of each item




<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://returnhistory--yamamayqa.myvtex.com)

#### Screenshots or example usage:

**Admin:**
<img width="1728" alt="Screen Shot 2022-02-25 at 12 52 46 PM" src="https://user-images.githubusercontent.com/51743718/155694793-5d71b00b-92c1-4a28-9b7a-ff55220c4f4a.png">
<img width="1721" alt="Screen Shot 2022-02-25 at 12 52 27 PM" src="https://user-images.githubusercontent.com/51743718/155694822-3de89a29-455a-4efa-87de-0cef9db231ca.png">
<img width="1728" alt="Screen Shot 2022-02-25 at 12 53 32 PM" src="https://user-images.githubusercontent.com/51743718/155694840-d00d4de6-ecda-4234-8b55-7f3a82351160.png">


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

