### PR TITLE
Hot fix/same as order payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed 
-- add `refundId` to returnRequests schema 
-
+### Changed 
+- Add `refundId` to `returnRequests` schema so it matches `returnProducts` and avoid breaking the search, which was preventing to display the history information in the RMAs.
 
 ### Added
 - A new setting to prevent customers changing to a different payment method, as a refund, from the one in the order.

--- a/react/components/RequestInfo.tsx
+++ b/react/components/RequestInfo.tsx
@@ -5,6 +5,8 @@ import { defineMessages, injectIntl } from 'react-intl'
 
 import styles from '../styles.css'
 
+export const SAME_AS_ORDER = 'sameAsOrder'
+
 interface Props {
   request: any
   giftCardValue: any
@@ -40,6 +42,7 @@ const RequestInfo: FunctionComponent<Props> = (props) => {
     voucherCode: { id: `returns.voucherCode` },
     voucherCodeNotGenerated: { id: `returns.voucherCodeNotGenerated` },
     voucherValue: { id: `returns.voucherValue` },
+    orderPaymentMethod: { id: `returns.orderPaymentMethod` },
   })
 
   return (
@@ -232,7 +235,9 @@ const RequestInfo: FunctionComponent<Props> = (props) => {
         <p
           className={`ma1 t-small c-on-base ${styles.requestInfoPaymentMethod}`}
         >
-          {request.paymentMethod}
+          {request.paymentMethod === SAME_AS_ORDER
+            ? formatMessage({ id: messages.orderPaymentMethod.id })
+            : request.paymentMethod}
         </p>
       )}
       {request.extraComment && request.extraComment !== '' && (

--- a/react/store/MyReturnsPageAdd.tsx
+++ b/react/store/MyReturnsPageAdd.tsx
@@ -22,6 +22,7 @@ import { fetchHeaders, fetchMethod, fetchPath } from '../common/fetch'
 import EligibleOrdersTable from '../components/EligibleOrdersTable'
 import RequestInformation from '../components/RequestInformation'
 import RequestForm from '../components/RequestForm'
+import { SAME_AS_ORDER } from '../components/RequestInfo'
 
 type Errors = {
   name: string
@@ -290,9 +291,7 @@ class MyReturnsPageAdd extends Component<Props, State> {
 
     if (this.state.settings.hidePaymentMethodSelection) {
       this.setState({
-        paymentMethod: this.props.intl.formatMessage({
-          id: messages.orderPaymentMethod.id,
-        }),
+        paymentMethod: SAME_AS_ORDER,
       })
     }
 


### PR DESCRIPTION
Hot fix to change the value passed to `paymentMethod` when creating RMA. The value was bigger than the limit defined by the schema. Now, we pass a string `sameAsOrder`. When the value matches, we show a translatable message for the store and admin users.