### PR TITLE
Handle errors

### DIFF
--- a/node/clients/masterdata.ts
+++ b/node/clients/masterdata.ts
@@ -123,7 +123,6 @@ export default class Masterdata extends ExternalClient {
     return true
   }
 
-
   public async getDocuments(
     ctx: any,
     schemaName: any,
@@ -154,10 +153,9 @@ export default class Masterdata extends ExternalClient {
   }
 
   public async getDocumentsWithPagination(
-      ctx: any,
-      options: any,
+    ctx: any,
+    options: any
   ): Promise<any> {
-
     return ctx.clients.masterdata.searchDocumentsWithPaginationInfo({
       dataEntity: this.schemas.schemaEntity,
       fields: [],

--- a/node/index.ts
+++ b/node/index.ts
@@ -24,6 +24,7 @@ import { changeProductStatus } from './middlewares/api/changeProductStatus'
 import { checkStatus } from './middlewares/api/checkStatus'
 import { updateStatus } from './middlewares/api/updateStatus'
 import { createRefund } from './middlewares/createRefund'
+import { errorHandler } from './middlewares/errorHandler'
 import { mutations } from './resolvers'
 
 const TIMEOUT_MS = 5000
@@ -52,70 +53,70 @@ export default new Service({
   clients,
   routes: {
     getSchemas: method({
-      GET: returnAppGetSchemas,
+      GET: [errorHandler, returnAppGetSchemas],
     }),
     generateSchema: method({
-      PUT: generateReturnsSchema,
+      PUT: [errorHandler, generateReturnsSchema],
     }),
     getDocuments: method({
-      GET: receiveDocuments,
+      GET: [errorHandler, receiveDocuments],
     }),
     getRequests: method({
-      GET: getRequests,
+      GET: [errorHandler, getRequests],
     }),
     getCategories: method({
-      GET: receiveCategories,
+      GET: [errorHandler, receiveCategories],
     }),
     getOrders: method({
-      GET: getOrders,
+      GET: [errorHandler, getOrders],
     }),
     getOrder: method({
-      GET: getOrder,
+      GET: [errorHandler, getOrder],
     }),
     saveDocuments: method({
-      POST: saveMasterdataDocuments,
+      POST: [errorHandler, saveMasterdataDocuments],
     }),
     savePartialDocument: method({
-      POST: saveMasterdataPartialDocuments,
+      POST: [errorHandler, saveMasterdataPartialDocuments],
     }),
     createGiftCard: method({
-      POST: createGiftCard,
+      POST: [errorHandler, createGiftCard],
     }),
     updateGiftCard: method({
-      POST: updateGiftCard,
+      POST: [errorHandler, updateGiftCard],
     }),
     getGiftCard: method({
-      GET: getGiftCard,
+      GET: [errorHandler, getGiftCard],
     }),
     getSkuById: method({
-      GET: getSkuById,
+      GET: [errorHandler, getSkuById],
     }),
     sendMail: method({
-      POST: sendMail,
+      POST: [errorHandler, sendMail],
     }),
     apiGetRequest: method({
-      GET: getRequest,
+      GET: [errorHandler, getRequest],
     }),
     apiGetList: method({
-      GET: getList,
+      GET: [errorHandler, getList],
     }),
     apiAddComment: method({
-      POST: addComment,
+      POST: [errorHandler, addComment],
     }),
     apiVerifyPackage: method({
-      POST: verifyPackage,
+      POST: [errorHandler, verifyPackage],
     }),
     apiChangeProductStatus: method({
-      POST: changeProductStatus,
+      POST: [errorHandler, changeProductStatus],
     }),
     apiCheckStatus: method({
-      GET: checkStatus,
+      GET: [errorHandler, checkStatus],
     }),
     apiUpdateStatus: method({
-      POST: updateStatus,
+      POST: [errorHandler, updateStatus],
     }),
     createRefund: method({
-      POST: createRefund,
+      POST: [errorHandler, createRefund],
     }),
   },
   graphql: {

--- a/node/middlewares/api/addComment.ts
+++ b/node/middlewares/api/addComment.ts
@@ -41,6 +41,10 @@ export async function addComment(ctx: Context, next: () => Promise<any>) {
       `id=${request_id}`
     )
 
+    if (!requestResponse) {
+      throw new Error(`Error getting documents before adding comment`)
+    }
+
     if (requestResponse.length) {
       const [response] = requestResponse
       const commentBody = {
@@ -53,7 +57,15 @@ export async function addComment(ctx: Context, next: () => Promise<any>) {
         refundId: request_id,
       }
 
-      await masterDataClient.saveDocuments(ctx, 'returnComments', commentBody)
+      const saveCommentResponse = await masterDataClient.saveDocuments(
+        ctx,
+        'returnComments',
+        commentBody
+      )
+
+      if (!saveCommentResponse) {
+        throw new Error(`Error saving comment`)
+      }
     } else {
       output = {
         ...output,

--- a/node/middlewares/api/changeProductStatus.ts
+++ b/node/middlewares/api/changeProductStatus.ts
@@ -52,6 +52,12 @@ export async function changeProductStatus(
       `id=${request_id}`
     )
 
+    if (!requestResponse) {
+      throw new Error(
+        `Error getting return documents before changing product status`
+      )
+    }
+
     // verificam daca exista o cerere de retur cu id-ul respectiv
     if (requestResponse.length) {
       if (requestResponse[0].status === requestsStatuses.refunded) {
@@ -79,6 +85,12 @@ export async function changeProductStatus(
           'product',
           `refundId=${request_id}__${searchField}`
         )
+
+        if (!requestResponse) {
+          throw new Error(
+            `Error getting product documents before changing product status`
+          )
+        }
 
         // verificam daca exista produsul in cererea de retur
         if (productResponse.length) {

--- a/node/middlewares/api/checkStatus.ts
+++ b/node/middlewares/api/checkStatus.ts
@@ -16,6 +16,10 @@ export async function checkStatus(ctx: Context, next: () => Promise<any>) {
     `id=${request_id}`
   )
 
+  if (!requestResponse) {
+    throw new Error(`Error getting return documents on checking status`)
+  }
+
   let output = {
     success: true,
     status: '',
@@ -51,6 +55,10 @@ export async function checkStatus(ctx: Context, next: () => Promise<any>) {
         'product',
         `refundId=${request_id}`
       )
+
+      if (!requestResponse) {
+        throw new Error(`Error getting product documents on checking status`)
+      }
 
       if (productsResponse.length) {
         productsResponse.forEach((product: any) => {

--- a/node/middlewares/api/getList.ts
+++ b/node/middlewares/api/getList.ts
@@ -34,6 +34,10 @@ export async function getList(ctx: Context, next: () => Promise<any>) {
     filterData
   )
 
+  if (!requestResponse) {
+    throw new Error(`Error getting list`)
+  }
+
   const output: any[] = []
 
   if (requestResponse.length) {
@@ -62,6 +66,10 @@ export async function getList(ctx: Context, next: () => Promise<any>) {
           `refundId=${request.id}`
         )
 
+        if (!statusHistoryResponse) {
+          throw new Error(`Error getting status history on get list`)
+        }
+
         const statusHistory: any[] = []
 
         if (statusHistoryResponse.length) {
@@ -77,6 +85,10 @@ export async function getList(ctx: Context, next: () => Promise<any>) {
           'comment',
           `refundId=${request.id}`
         )
+
+        if (!commentsResponse) {
+          throw new Error(`Error getting comments`)
+        }
 
         const comments: any[] = []
 

--- a/node/middlewares/api/getRequest.ts
+++ b/node/middlewares/api/getRequest.ts
@@ -21,6 +21,10 @@ export async function getRequest(ctx: Context, next: () => Promise<any>) {
     `id=${request_id}`
   )
 
+  if (!requestResponse) {
+    throw new Error(`Error getting request`)
+  }
+
   let output = {
     success: false,
     errorMessage: 'Not Found',
@@ -36,6 +40,10 @@ export async function getRequest(ctx: Context, next: () => Promise<any>) {
       'product',
       `refundId=${request_id}`
     )
+
+    if (!productsResponse) {
+      throw new Error(`Error getting products request`)
+    }
 
     const products: any[] = []
 
@@ -53,6 +61,10 @@ export async function getRequest(ctx: Context, next: () => Promise<any>) {
       `refundId=${request_id}`
     )
 
+    if (!statusHistoryResponse) {
+      throw new Error(`Error getting status history request`)
+    }
+
     const statusHistory: any[] = []
 
     if (statusHistoryResponse.length) {
@@ -68,6 +80,10 @@ export async function getRequest(ctx: Context, next: () => Promise<any>) {
       'comment',
       `refundId=${request_id}`
     )
+
+    if (!commentsResponse) {
+      throw new Error(`Error getting comments response`)
+    }
 
     const comments: any[] = []
 

--- a/node/middlewares/createGiftCard.ts
+++ b/node/middlewares/createGiftCard.ts
@@ -4,13 +4,24 @@ export async function createGiftCard(ctx: Context, next: () => Promise<any>) {
   const body = await json(ctx.req)
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
-  const response = await returnAppClient.createGiftCard(ctx, body)
+  try {
+    const response = await returnAppClient.createGiftCard(ctx, body)
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
 
-  await next()
+    await next()
+  } catch (e) {
+    logger.error({
+      message: `Error creating creating gift card`,
+      error: e,
+      data: {
+        body,
+      },
+    })
+  }
 }

--- a/node/middlewares/createGiftCard.ts
+++ b/node/middlewares/createGiftCard.ts
@@ -10,11 +10,13 @@ export async function createGiftCard(ctx: Context, next: () => Promise<any>) {
   try {
     const response = await returnAppClient.createGiftCard(ctx, body)
 
+    logger.info({
+      message: 'Created giftcard successfully',
+      data: response,
+    })
     ctx.status = 200
     ctx.set('Cache-Control', 'no-cache')
     ctx.body = response
-
-    await next()
   } catch (e) {
     logger.error({
       message: `Error creating creating gift card`,
@@ -24,4 +26,6 @@ export async function createGiftCard(ctx: Context, next: () => Promise<any>) {
       },
     })
   }
+
+  await next()
 }

--- a/node/middlewares/createGiftCard.ts
+++ b/node/middlewares/createGiftCard.ts
@@ -7,25 +7,20 @@ export async function createGiftCard(ctx: Context, next: () => Promise<any>) {
     vtex: { logger },
   } = ctx
 
-  try {
-    const response = await returnAppClient.createGiftCard(ctx, body)
+  const response = await returnAppClient.createGiftCard(ctx, body)
 
-    logger.info({
-      message: 'Created giftcard successfully',
-      data: response,
-    })
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error creating creating gift card`,
-      error: e,
-      data: {
-        body,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error creating gift card`)
   }
+
+  logger.info({
+    message: 'Created giftcard successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/createRefund.ts
+++ b/node/middlewares/createRefund.ts
@@ -9,26 +9,20 @@ export async function createRefund(ctx: Context, next: () => Promise<any>) {
   const { orderId } = ctx.vtex.route.params
   const body = await json(ctx.req)
 
-  try {
-    const response = await returnAppClient.createRefund(ctx, orderId, body)
+  const response = await returnAppClient.createRefund(ctx, orderId, body)
 
-    logger.info({
-      message: `Created refund successfully for orderId ${orderId}`,
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error creating refund for order ID ${orderId}`,
-      error: e,
-      data: {
-        body,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error creating refund for id: ${orderId}`)
   }
+
+  logger.info({
+    message: `Created refund successfully for orderId ${orderId}`,
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/createRefund.ts
+++ b/node/middlewares/createRefund.ts
@@ -3,15 +3,27 @@ import { json } from 'co-body'
 export async function createRefund(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
   const { orderId } = ctx.vtex.route.params
   const body = await json(ctx.req)
-  const response = await returnAppClient.createRefund(ctx, orderId, body)
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+  try {
+    const response = await returnAppClient.createRefund(ctx, orderId, body)
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error creating refund for order ID ${orderId}`,
+      error: e,
+      data: {
+        body,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/createRefund.ts
+++ b/node/middlewares/createRefund.ts
@@ -12,6 +12,11 @@ export async function createRefund(ctx: Context, next: () => Promise<any>) {
   try {
     const response = await returnAppClient.createRefund(ctx, orderId, body)
 
+    logger.info({
+      message: `Created refund successfully for orderId ${orderId}`,
+      data: response,
+    })
+
     ctx.status = 200
     ctx.set('Cache-Control', 'no-cache')
     ctx.body = response

--- a/node/middlewares/errorHandler.ts
+++ b/node/middlewares/errorHandler.ts
@@ -1,0 +1,15 @@
+export async function errorHandler(ctx: Context, next: () => Promise<void>) {
+  const {
+    vtex: { logger },
+  } = ctx
+
+  console.log('running error handler')
+  try {
+    await next()
+  } catch (error) {
+    logger.error({
+      message: error.message,
+      error,
+    })
+  }
+}

--- a/node/middlewares/generateReturnsSchema.ts
+++ b/node/middlewares/generateReturnsSchema.ts
@@ -4,13 +4,24 @@ export async function generateReturnsSchema(
 ) {
   const {
     clients: { masterData: masterDataClient },
+    vtex: { logger },
   } = ctx
 
-  const response = await masterDataClient.generateSchema(ctx)
+  try {
+    const response = await masterDataClient.generateSchema(ctx)
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error generating schema`,
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/generateReturnsSchema.ts
+++ b/node/middlewares/generateReturnsSchema.ts
@@ -7,26 +7,20 @@ export async function generateReturnsSchema(
     vtex: { logger },
   } = ctx
 
-  try {
-    const response = await masterDataClient.generateSchema(ctx)
+  const response = await masterDataClient.generateSchema(ctx)
 
-    logger.info({
-      message: 'Schema generated successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error generating schema`,
-      error: e,
-      data: {
-        ctx,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error generating schema`)
   }
+
+  logger.info({
+    message: 'Schema generated successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/generateReturnsSchema.ts
+++ b/node/middlewares/generateReturnsSchema.ts
@@ -10,6 +10,11 @@ export async function generateReturnsSchema(
   try {
     const response = await masterDataClient.generateSchema(ctx)
 
+    logger.info({
+      message: 'Schema generated successfully',
+      data: response,
+    })
+
     ctx.status = 200
     ctx.set('Cache-Control', 'no-cache')
     ctx.body = response

--- a/node/middlewares/getGiftCard.ts
+++ b/node/middlewares/getGiftCard.ts
@@ -6,25 +6,19 @@ export async function getGiftCard(ctx: Context, next: () => Promise<any>) {
 
   const { id } = ctx.vtex.route.params
 
-  try {
-    const response = await returnAppClient.getGiftCard(ctx, id)
+  const response = await returnAppClient.getGiftCard(ctx, id)
 
-    logger.info({
-      message: 'Gift card successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error fetching gift card`,
-      error: e,
-      data: {
-        ctx,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error getting gift card with id: ${id}`)
   }
+
+  logger.info({
+    message: 'Gift card successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/getGiftCard.ts
+++ b/node/middlewares/getGiftCard.ts
@@ -1,13 +1,30 @@
 export async function getGiftCard(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
   const { id } = ctx.vtex.route.params
-  const response = await returnAppClient.getGiftCard(ctx, id)
 
-  ctx.status = 200
-  ctx.body = response
+  try {
+    const response = await returnAppClient.getGiftCard(ctx, id)
+
+    logger.info({
+      message: 'Gift card successfully',
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error fetching gift card`,
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/getOrder.ts
+++ b/node/middlewares/getOrder.ts
@@ -1,14 +1,30 @@
 export async function getOrder(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
   const { orderId } = ctx.vtex.route.params
 
-  const response = await returnAppClient.getOrder(ctx, orderId)
+  try {
+    const response = await returnAppClient.getOrder(ctx, orderId)
 
-  ctx.status = 200
-  ctx.body = response
+    logger.info({
+      message: 'Get order successfully',
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error fetching order: ${orderId}`,
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/getOrder.ts
+++ b/node/middlewares/getOrder.ts
@@ -6,25 +6,19 @@ export async function getOrder(ctx: Context, next: () => Promise<any>) {
 
   const { orderId } = ctx.vtex.route.params
 
-  try {
-    const response = await returnAppClient.getOrder(ctx, orderId)
+  const response = await returnAppClient.getOrder(ctx, orderId)
 
-    logger.info({
-      message: 'Get order successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error fetching order: ${orderId}`,
-      error: e,
-      data: {
-        ctx,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error getting order`)
   }
+
+  logger.info({
+    message: 'Get order successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/getOrders.ts
+++ b/node/middlewares/getOrders.ts
@@ -1,14 +1,32 @@
 export async function getOrders(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
   const { where } = ctx.vtex.route.params
-  const response = await returnAppClient.getOrders(ctx, where)
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+  try {
+    const response = await returnAppClient.getOrders(ctx, where)
+
+    logger.info({
+      message: 'Get orders successfully',
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error fetching orders`,
+      error: e,
+      data: {
+        ctx,
+        where,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/getOrders.ts
+++ b/node/middlewares/getOrders.ts
@@ -6,27 +6,20 @@ export async function getOrders(ctx: Context, next: () => Promise<any>) {
 
   const { where } = ctx.vtex.route.params
 
-  try {
-    const response = await returnAppClient.getOrders(ctx, where)
+  const response = await returnAppClient.getOrders(ctx, where)
 
-    logger.info({
-      message: 'Get orders successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error fetching orders`,
-      error: e,
-      data: {
-        ctx,
-        where,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error getting orders`)
   }
+
+  logger.info({
+    message: 'Get orders successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/getRequests.ts
+++ b/node/middlewares/getRequests.ts
@@ -16,30 +16,23 @@ export async function getRequests(ctx: Context, next: () => Promise<any>) {
     pageSize,
   }
 
-  try {
-    const response = await masterDataClient.getDocumentsWithPagination(
-      ctx,
-      options
-    )
+  const response = await masterDataClient.getDocumentsWithPagination(
+    ctx,
+    options
+  )
 
-    logger.info({
-      message: 'Get requests with pagination successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error getting requests with pagination`,
-      error: e,
-      data: {
-        ctx,
-        options,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error getting requests`)
   }
+
+  logger.info({
+    message: 'Get requests with pagination successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/getRequests.ts
+++ b/node/middlewares/getRequests.ts
@@ -1,9 +1,11 @@
 export async function getRequests(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { masterData: masterDataClient },
+    vtex: { logger },
   } = ctx
 
-  const { schemaName, whereClause, page, pageSize, sortBy, sortOrder } = ctx.vtex.route.params
+  const { schemaName, whereClause, page, pageSize, sortBy, sortOrder } =
+    ctx.vtex.route.params
 
   const options = {
     schema: schemaName,
@@ -11,16 +13,33 @@ export async function getRequests(ctx: Context, next: () => Promise<any>) {
     sortBy,
     sortOrder,
     page,
-    pageSize
+    pageSize,
   }
-  const response = await masterDataClient.getDocumentsWithPagination(
-    ctx,
-    options
-  )
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+  try {
+    const response = await masterDataClient.getDocumentsWithPagination(
+      ctx,
+      options
+    )
+
+    logger.info({
+      message: 'Get requests with pagination successfully',
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error getting requests with pagination`,
+      error: e,
+      data: {
+        ctx,
+        options,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/getSkuById.ts
+++ b/node/middlewares/getSkuById.ts
@@ -1,13 +1,30 @@
 export async function getSkuById(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
   const { id } = ctx.vtex.route.params
-  const response = await returnAppClient.getSkuById(ctx, id)
 
-  ctx.status = 200
-  ctx.body = response
+  try {
+    const response = await returnAppClient.getSkuById(ctx, id)
+
+    logger.info({
+      message: 'Get SKU by id successfully',
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error getting SKU by id: ${id}`,
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/getSkuById.ts
+++ b/node/middlewares/getSkuById.ts
@@ -6,29 +6,19 @@ export async function getSkuById(ctx: Context, next: () => Promise<any>) {
 
   const { id } = ctx.vtex.route.params
 
-  try {
-    const response = await returnAppClient.getSkuById(ctx, id)
+  const response = await returnAppClient.getSkuById(ctx, id)
 
-    if (!response) {
-      throw new Error(`Error getting SkuById for id: ${id}`)
-    }
-
-    logger.info({
-      message: 'Get SKU by id successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error getting SKU by id: ${id}`,
-      error: e,
-      data: {
-        ctx,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error getting SkuById for id: ${id}`)
   }
+
+  logger.info({
+    message: 'Get SKU by id successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/getSkuById.ts
+++ b/node/middlewares/getSkuById.ts
@@ -9,6 +9,10 @@ export async function getSkuById(ctx: Context, next: () => Promise<any>) {
   try {
     const response = await returnAppClient.getSkuById(ctx, id)
 
+    if (!response) {
+      throw new Error(`Error getting SkuById for id: ${id}`)
+    }
+
     logger.info({
       message: 'Get SKU by id successfully',
       data: response,

--- a/node/middlewares/receiveCategories.ts
+++ b/node/middlewares/receiveCategories.ts
@@ -4,12 +4,28 @@ export async function receiveCategories(
 ) {
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
-  const response = await returnAppClient.getCategories(ctx)
+  try {
+    const response = await returnAppClient.getCategories(ctx)
 
-  ctx.status = 200
-  ctx.body = response
+    logger.info({
+      message: 'Received categories successfully',
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error receiving categories`,
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/receiveCategories.ts
+++ b/node/middlewares/receiveCategories.ts
@@ -7,25 +7,19 @@ export async function receiveCategories(
     vtex: { logger },
   } = ctx
 
-  try {
-    const response = await returnAppClient.getCategories(ctx)
+  const response = await returnAppClient.getCategories(ctx)
 
-    logger.info({
-      message: 'Received categories successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error receiving categories`,
-      error: e,
-      data: {
-        ctx,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error receiving categories`)
   }
+
+  logger.info({
+    message: 'Received categories successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/receiveDocuments.ts
+++ b/node/middlewares/receiveDocuments.ts
@@ -1,4 +1,4 @@
-export async function receiveDocuments(ctx: Context, next: () => Promise<any>) {
+export async function receiveDocuments(ctx: Context) {
   const {
     clients: { masterData: masterDataClient },
     vtex: { logger },
@@ -6,33 +6,25 @@ export async function receiveDocuments(ctx: Context, next: () => Promise<any>) {
 
   const { schemaName, whereClause, type } = ctx.vtex.route.params
 
-  try {
-    const response = await masterDataClient.getDocuments(
-      ctx,
-      schemaName,
-      type,
-      whereClause
+  const response = await masterDataClient.getDocuments(
+    ctx,
+    schemaName,
+    type,
+    whereClause
+  )
+
+  if (!response) {
+    throw new Error(
+      `Error receiving documents on type: ${type} on schema: ${schemaName} where: ${whereClause}`
     )
-
-    logger.info({
-      message: 'Received documents successfully',
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-    await next()
-  } catch (e) {
-    logger.error({
-      message: 'error receiving docs',
-      error: e,
-      data: {
-        ctx,
-      },
-    })
-
-    throw e
   }
-  // message: `Error receiving documents on type: ${type} on schema: ${schemaName} where: ${whereClause}`,
+
+  logger.info({
+    message: 'Received documents successfully',
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 }

--- a/node/middlewares/receiveDocuments.ts
+++ b/node/middlewares/receiveDocuments.ts
@@ -1,19 +1,38 @@
 export async function receiveDocuments(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { masterData: masterDataClient },
+    vtex: { logger },
   } = ctx
 
   const { schemaName, whereClause, type } = ctx.vtex.route.params
-  const response = await masterDataClient.getDocuments(
-    ctx,
-    schemaName,
-    type,
-    whereClause
-  )
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+  try {
+    const response = await masterDataClient.getDocuments(
+      ctx,
+      schemaName,
+      type,
+      whereClause
+    )
 
-  await next()
+    logger.info({
+      message: 'Received documents successfully',
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+    await next()
+  } catch (e) {
+    logger.error({
+      message: 'error receiving docs',
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+
+    throw e
+  }
+  // message: `Error receiving documents on type: ${type} on schema: ${schemaName} where: ${whereClause}`,
 }

--- a/node/middlewares/returnAppGetSchemas.ts
+++ b/node/middlewares/returnAppGetSchemas.ts
@@ -9,26 +9,20 @@ export async function returnAppGetSchemas(
 
   const { schema } = ctx.vtex.route.params
 
-  try {
-    const response = await masterDataClient.getSchema(ctx, schema.toString())
+  const response = await masterDataClient.getSchema(ctx, schema.toString())
 
-    logger.info({
-      message: `Get schema ${schema} successfully`,
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error getting schema: ${schema}`,
-      error: e,
-      data: {
-        ctx,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error getting schema: ${schema}`)
   }
+
+  logger.info({
+    message: `Get schema ${schema} successfully`,
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/returnAppGetSchemas.ts
+++ b/node/middlewares/returnAppGetSchemas.ts
@@ -4,15 +4,31 @@ export async function returnAppGetSchemas(
 ) {
   const {
     clients: { masterData: masterDataClient },
+    vtex: { logger },
   } = ctx
 
   const { schema } = ctx.vtex.route.params
 
-  const response = await masterDataClient.getSchema(ctx, schema.toString())
+  try {
+    const response = await masterDataClient.getSchema(ctx, schema.toString())
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+    logger.info({
+      message: `Get schema ${schema} successfully`,
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error getting schema: ${schema}`,
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/saveMasterdataDocuments.ts
+++ b/node/middlewares/saveMasterdataDocuments.ts
@@ -7,14 +7,34 @@ export async function saveMasterdataDocuments(
   const body = await json(ctx.req)
   const {
     clients: { masterData: masterDataClient },
+    vtex: { logger },
   } = ctx
 
   const { schemaName } = ctx.vtex.route.params
-  const response = await masterDataClient.saveDocuments(ctx, schemaName, body)
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+  try {
+    const response = await masterDataClient.saveDocuments(ctx, schemaName, body)
+
+    logger.info({
+      message: `Save documents on ${schemaName} successfully`,
+      data: response,
+    })
+
+    throw new Error('error sending email')
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error saving documents on schema: ${schemaName}`,
+      error: e,
+      data: {
+        ctx,
+        body,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/saveMasterdataDocuments.ts
+++ b/node/middlewares/saveMasterdataDocuments.ts
@@ -12,29 +12,20 @@ export async function saveMasterdataDocuments(
 
   const { schemaName } = ctx.vtex.route.params
 
-  try {
-    const response = await masterDataClient.saveDocuments(ctx, schemaName, body)
+  const response = await masterDataClient.saveDocuments(ctx, schemaName, body)
 
-    logger.info({
-      message: `Save documents on ${schemaName} successfully`,
-      data: response,
-    })
-
-    throw new Error('error sending email')
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error saving documents on schema: ${schemaName}`,
-      error: e,
-      data: {
-        ctx,
-        body,
-      },
-    })
+  if (!response) {
+    throw new Error('Error saving MasterData documents')
   }
+
+  logger.info({
+    message: `Save documents on ${schemaName} successfully`,
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/saveMasterdataPartialDocuments.ts
+++ b/node/middlewares/saveMasterdataPartialDocuments.ts
@@ -7,14 +7,32 @@ export async function saveMasterdataPartialDocuments(
   const body = await json(ctx.req)
   const {
     clients: { masterData: masterDataClient },
+    vtex: { logger },
   } = ctx
 
   const { schemaName } = ctx.vtex.route.params
-  const response = await masterDataClient.savePartial(ctx, schemaName, body)
 
-  ctx.status = 200
-  ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+  try {
+    const response = await masterDataClient.savePartial(ctx, schemaName, body)
+
+    logger.info({
+      message: `Save partial documents on ${schemaName} successfully`,
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error saving partial documents on schema: ${schemaName}`,
+      error: e,
+      data: {
+        ctx,
+        body,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/saveMasterdataPartialDocuments.ts
+++ b/node/middlewares/saveMasterdataPartialDocuments.ts
@@ -12,27 +12,20 @@ export async function saveMasterdataPartialDocuments(
 
   const { schemaName } = ctx.vtex.route.params
 
-  try {
-    const response = await masterDataClient.savePartial(ctx, schemaName, body)
+  const response = await masterDataClient.savePartial(ctx, schemaName, body)
 
-    logger.info({
-      message: `Save partial documents on ${schemaName} successfully`,
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.set('Cache-Control', 'no-cache')
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error saving partial documents on schema: ${schemaName}`,
-      error: e,
-      data: {
-        ctx,
-        body,
-      },
-    })
+  if (!response) {
+    throw new Error('Error sending email')
   }
+
+  logger.info({
+    message: `Save partial documents on ${schemaName} successfully`,
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.set('Cache-Control', 'no-cache')
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/saveMasterdataPartialDocuments.ts
+++ b/node/middlewares/saveMasterdataPartialDocuments.ts
@@ -15,7 +15,7 @@ export async function saveMasterdataPartialDocuments(
   const response = await masterDataClient.savePartial(ctx, schemaName, body)
 
   if (!response) {
-    throw new Error('Error sending email')
+    throw new Error('Error saving MasterData partial documents')
   }
 
   logger.info({

--- a/node/middlewares/sendMail.ts
+++ b/node/middlewares/sendMail.ts
@@ -7,28 +7,19 @@ export async function sendMail(ctx: Context, next: () => Promise<any>) {
     vtex: { logger },
   } = ctx
 
-  try {
-    const response = await returnAppClient.sendMail(ctx, body)
+  const response = await returnAppClient.sendMail(ctx, body)
 
-    logger.info({
-      message: `Send email successfully`,
-      data: response,
-    })
-
-    throw new Error('error sending email')
-
-    ctx.status = 200
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error sending email`,
-      error: e,
-      data: {
-        ctx,
-        body,
-      },
-    })
+  if (!response) {
+    throw new Error('Error sending email')
   }
+
+  logger.info({
+    message: `Send email successfully`,
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.body = response
 
   await next()
 }

--- a/node/middlewares/sendMail.ts
+++ b/node/middlewares/sendMail.ts
@@ -4,12 +4,31 @@ export async function sendMail(ctx: Context, next: () => Promise<any>) {
   const body = await json(ctx.req)
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
-  const response = await returnAppClient.sendMail(ctx, body)
+  try {
+    const response = await returnAppClient.sendMail(ctx, body)
 
-  ctx.status = 200
-  ctx.body = response
+    logger.info({
+      message: `Send email successfully`,
+      data: response,
+    })
+
+    throw new Error('error sending email')
+
+    ctx.status = 200
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error sending email`,
+      error: e,
+      data: {
+        ctx,
+        body,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/updateGiftCard.ts
+++ b/node/middlewares/updateGiftCard.ts
@@ -3,14 +3,32 @@ import { json } from 'co-body'
 export async function updateGiftCard(ctx: Context, next: () => Promise<any>) {
   const {
     clients: { returnApp: returnAppClient },
+    vtex: { logger },
   } = ctx
 
   const { id } = ctx.vtex.route.params
   const body = await json(ctx.req)
-  const response = await returnAppClient.updateGiftCard(ctx, id, body)
 
-  ctx.status = 200
-  ctx.body = response
+  try {
+    const response = await returnAppClient.updateGiftCard(ctx, id, body)
+
+    logger.info({
+      message: `Update gift card successfully`,
+      data: response,
+    })
+
+    ctx.status = 200
+    ctx.body = response
+  } catch (e) {
+    logger.error({
+      message: `Error updating gift card with id: ${id}`,
+      error: e,
+      data: {
+        ctx,
+        body,
+      },
+    })
+  }
 
   await next()
 }

--- a/node/middlewares/updateGiftCard.ts
+++ b/node/middlewares/updateGiftCard.ts
@@ -9,26 +9,19 @@ export async function updateGiftCard(ctx: Context, next: () => Promise<any>) {
   const { id } = ctx.vtex.route.params
   const body = await json(ctx.req)
 
-  try {
-    const response = await returnAppClient.updateGiftCard(ctx, id, body)
+  const response = await returnAppClient.updateGiftCard(ctx, id, body)
 
-    logger.info({
-      message: `Update gift card successfully`,
-      data: response,
-    })
-
-    ctx.status = 200
-    ctx.body = response
-  } catch (e) {
-    logger.error({
-      message: `Error updating gift card with id: ${id}`,
-      error: e,
-      data: {
-        ctx,
-        body,
-      },
-    })
+  if (!response) {
+    throw new Error(`Error updating giftcard with id ${id}`)
   }
+
+  logger.info({
+    message: `Update gift card successfully`,
+    data: response,
+  })
+
+  ctx.status = 200
+  ctx.body = response
 
   await next()
 }

--- a/node/resolvers/deleteReturnRequest.ts
+++ b/node/resolvers/deleteReturnRequest.ts
@@ -6,13 +6,29 @@ export const deleteReturnRequest = async (
   const { Id } = args
   const {
     clients: { mdFactory },
+    vtex: { logger },
   } = ctx
 
   const promises = Id.map((id) => {
     return mdFactory.deleteRMADocument(id)
   })
 
-  await Promise.all(promises)
+  try {
+    const response = await Promise.all(promises)
+
+    logger.info({
+      message: `Return request documents deleted successfully`,
+      data: response,
+    })
+  } catch (e) {
+    logger.error({
+      message: `Error deleting return request documents with IDs: ${Id}`,
+      error: e,
+      data: {
+        ctx,
+      },
+    })
+  }
 
   return true
 }


### PR DESCRIPTION
What this PR changes:
Improve error handling and use splunk logger method in order to see on the platform.


How to test it:
[this workspace](https://zekiqa--vtexspain.myvtex.com/account#/my-returns).
Add a `throw new Error('any message')` on any defined route go to to the given workspace reload the page and then you can see the error on splunk.
`receiveDocuments.ts` is a good file to test because it loads on the root of the app.