### PR TITLE
feat: create middleware that validate orders and products that belongs to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added 
+- Add `getProfileEmailAndId.tsx` middleware to validate any request from sessionCookie, and get the user's email and id from the session. then pass them to the next middleware in the state.
+- Add `statusToError.ts` convert the status code to error message by passing the status number and error message.
+ 
 ## [2.19.0] - 2022-02-28
 ### Changed 
 - Add `refundId` to `returnRequests` schema so it matches `returnProducts` and avoid breaking the search, which was preventing to display the history information in the RMAs.

--- a/node/index.ts
+++ b/node/index.ts
@@ -51,6 +51,8 @@ declare global {
     userEmail?: string
     userId?: string
     isAdmin?: boolean
+    adminUserAuthToken?: string
+    storeUserAuthToken?: string
   }
 }
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -50,6 +50,7 @@ declare global {
   interface State extends RecorderState {
     userEmail?: string
     userId?: string
+    isAdmin?: boolean
   }
 }
 
@@ -63,7 +64,7 @@ export default new Service({
       PUT: [errorHandler, generateReturnsSchema],
     }),
     getDocuments: method({
-      GET: [errorHandler, getProfileEmailAndId, receiveDocuments],
+      GET: [getProfileEmailAndId, receiveDocuments],
     }),
     getRequests: method({
       GET: [errorHandler, getRequests],
@@ -72,10 +73,10 @@ export default new Service({
       GET: [errorHandler, receiveCategories],
     }),
     getOrders: method({
-      GET: [errorHandler, getProfileEmailAndId, getOrders],
+      GET: [getProfileEmailAndId, getOrders],
     }),
     getOrder: method({
-      GET: [errorHandler, getProfileEmailAndId, getOrder],
+      GET: [getProfileEmailAndId, getOrder],
     }),
     saveDocuments: method({
       POST: [errorHandler, saveMasterdataDocuments],

--- a/node/index.ts
+++ b/node/index.ts
@@ -25,6 +25,7 @@ import { checkStatus } from './middlewares/api/checkStatus'
 import { updateStatus } from './middlewares/api/updateStatus'
 import { createRefund } from './middlewares/createRefund'
 import { mutations } from './resolvers'
+import { getProfileEmailAndId } from './middlewares/getProfileEmailAndId'
 
 const TIMEOUT_MS = 5000
 const memoryCache = new LRUCache<string, any>({ max: 5000 })
@@ -45,7 +46,10 @@ const clients: ClientsConfig<Clients> = {
 declare global {
   type Context = ServiceContext<Clients, State>
 
-  type State = RecorderState
+  interface State extends RecorderState {
+    userEmail?: string
+    userId?: string
+  }
 }
 
 export default new Service({
@@ -58,7 +62,7 @@ export default new Service({
       PUT: generateReturnsSchema,
     }),
     getDocuments: method({
-      GET: receiveDocuments,
+      GET: [getProfileEmailAndId, receiveDocuments],
     }),
     getRequests: method({
       GET: getRequests,
@@ -67,10 +71,10 @@ export default new Service({
       GET: receiveCategories,
     }),
     getOrders: method({
-      GET: getOrders,
+      GET: [getProfileEmailAndId, getOrders],
     }),
     getOrder: method({
-      GET: getOrder,
+      GET: [getProfileEmailAndId, getOrder],
     }),
     saveDocuments: method({
       POST: saveMasterdataDocuments,

--- a/node/middlewares/getOrder.ts
+++ b/node/middlewares/getOrder.ts
@@ -11,11 +11,23 @@ export async function getOrder(ctx: Context) {
 
   const response = await returnAppClient.getOrder(ctx, orderId)
 
+  const { userId, isAdmin } = state
+
+  if (isAdmin) {
+    /**
+     * here we can use the adminUserAuthToken, so we can get the data from the admin account.
+     */
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+    return
+  }
+
   if (!response) {
     throw new Error(`Error getting order`)
   }
 
-  const { userId } = state
   const { userProfileId } = response.clientProfileData
 
   if (userId !== userProfileId) {

--- a/node/middlewares/getOrder.ts
+++ b/node/middlewares/getOrder.ts
@@ -1,14 +1,27 @@
-export async function getOrder(ctx: Context, next: () => Promise<any>) {
+import { statusToError } from '../utils/statusToError'
+
+export async function getOrder(ctx: Context) {
   const {
     clients: { returnApp: returnAppClient },
+    state,
   } = ctx
 
   const { orderId } = ctx.vtex.route.params
 
   const response = await returnAppClient.getOrder(ctx, orderId)
 
+  const { userId } = state
+  const { userProfileId } = response.clientProfileData
+
+  const hasAllIDs = userId && userProfileId
+
+  if (!hasAllIDs && userId !== userProfileId) {
+    throw statusToError({
+      status: 401,
+      message: 'unauthorized',
+    })
+  }
+
   ctx.status = 200
   ctx.body = response
-
-  await next()
 }

--- a/node/middlewares/getOrder.ts
+++ b/node/middlewares/getOrder.ts
@@ -11,20 +11,18 @@ export async function getOrder(ctx: Context) {
 
   const response = await returnAppClient.getOrder(ctx, orderId)
 
+  if (!response) {
+    throw new Error(`Error getting order`)
+  }
+
   const { userId } = state
   const { userProfileId } = response.clientProfileData
 
-  const hasAllIDs = userId && userProfileId
-
-  if (!hasAllIDs && userId !== userProfileId) {
+  if (userId !== userProfileId) {
     throw statusToError({
       status: 401,
       message: 'unauthorized',
     })
-  }
-
-  if (!response) {
-    throw new Error(`Error getting order`)
   }
 
   logger.info({

--- a/node/middlewares/getOrders.ts
+++ b/node/middlewares/getOrders.ts
@@ -1,14 +1,43 @@
-export async function getOrders(ctx: Context, next: () => Promise<any>) {
+/* eslint import/no-nodejs-modules: ["error", {"allow": ["url"]}] */
+import { URLSearchParams } from 'url'
+/** @ref https://nodejs.org/api/url.html#new-urlsearchparams */
+export async function getOrders(ctx: Context) {
   const {
     clients: { returnApp: returnAppClient },
+    state,
   } = ctx
 
+  const { userEmail } = state
+
   const { where } = ctx.vtex.route.params
-  const response = await returnAppClient.getOrders(ctx, where)
 
-  ctx.status = 200
   ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
+  ctx.status = 200
 
-  await next()
+  const hasUserEmail = userEmail && userEmail.length > 0 // just double check if the state has the userEmail.
+
+  if (!where && hasUserEmail) {
+    const response = await returnAppClient.getOrders(
+      ctx,
+      `clientEmail=${userEmail}`
+    )
+
+    ctx.body = response
+
+    return
+  } // gaurd against empty params
+
+  if (typeof where === 'string' && hasUserEmail) {
+    const queries = new URLSearchParams(where)
+
+    /**
+     * Always we set the clientEmail with the userEmail in the URL params just in case if someone passes in the url with different email or null or empty string.
+     * also it will cover the case when pass only all with page and page_number as well or any other queries, so it reduce the code and make it easier to maintain.
+     */
+    queries.set('clientEmail', userEmail as string)
+
+    const response = await returnAppClient.getOrders(ctx, queries.toString())
+
+    ctx.body = response
+  }
 }

--- a/node/middlewares/getOrders.ts
+++ b/node/middlewares/getOrders.ts
@@ -8,13 +8,22 @@ export async function getOrders(ctx: Context) {
     vtex: { logger },
   } = ctx
 
-  const { userEmail } = state
+  const { userEmail, isAdmin } = state
 
   const { where } = ctx.vtex.route.params
 
-
   const response = await returnAppClient.getOrders(ctx, where)
 
+  if (isAdmin) {
+    /**
+     * here we can use the adminUserAuthToken, so we can get the data from the admin account.
+     */
+
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    ctx.body = response
+    return
+  }
   if (!response) {
     throw new Error(`Error getting orders`)
   }
@@ -26,7 +35,6 @@ export async function getOrders(ctx: Context) {
 
   ctx.status = 200
   ctx.set('Cache-Control', 'no-cache')
-  ctx.status = 200
 
   const hasUserEmail = userEmail && userEmail.length > 0 // just double check if the state has the userEmail.
 

--- a/node/middlewares/getProfileEmailAndId.ts
+++ b/node/middlewares/getProfileEmailAndId.ts
@@ -1,0 +1,46 @@
+import { statusToError } from '../utils/statusToError'
+
+const VTEX_SESSION = 'vtex_session'
+
+const getProfileEmailAndId = async (
+  { clients: { session }, cookies, state }: Context,
+  next: () => Promise<void>
+) => {
+  try {
+    const sessionCookie = cookies.get(VTEX_SESSION)
+
+    if (!sessionCookie) {
+      throw statusToError({
+        status: 401,
+        message: 'Profile not found',
+      })
+    }
+
+    const { sessionData } = await session.getSession(sessionCookie, [
+      'profile.email',
+      'profile.id',
+    ])
+
+    const email = sessionData?.namespaces?.profile.email.value
+    const userId = sessionData?.namespaces?.profile.id.value
+
+    if (!email || !userId) {
+      throw statusToError({
+        status: 401,
+        message: 'Profile not found',
+      })
+    }
+
+    state.userEmail = email
+    state.userId = userId
+
+    await next()
+  } catch (error) {
+    throw statusToError({
+      status: 401,
+      message: 'Profile not found',
+    })
+  }
+}
+
+export { getProfileEmailAndId }

--- a/node/middlewares/receiveDocuments.ts
+++ b/node/middlewares/receiveDocuments.ts
@@ -1,9 +1,43 @@
-export async function receiveDocuments(ctx: Context, next: () => Promise<any>) {
+/* eslint import/no-nodejs-modules: ["error", {"allow": ["url"]}] */
+import { URLSearchParams } from 'url' /** @ref https://nodejs.org/api/url.html#new-urlsearchparams */
+
+import type { RETURNS_SCHEMA, PRODUCTS_SCHEMA } from '../../common/constants'
+import { statusToError } from '../utils/statusToError'
+
+type ReturnKeys = keyof typeof RETURNS_SCHEMA.properties
+type ProductKeys = keyof typeof PRODUCTS_SCHEMA.properties
+
+type ReturnRequests = {
+  [Key in ReturnKeys]: string
+}
+
+type ProductRequests = {
+  [Key in ProductKeys]: string
+}
+
+export async function receiveDocuments(ctx: Context) {
   const {
     clients: { masterData: masterDataClient },
+    state,
   } = ctx
 
   const { schemaName, whereClause, type } = ctx.vtex.route.params
+
+  const { userId } = state
+  const whereClauseQueries = new URLSearchParams(whereClause as string)
+
+  const userIdFromURL = whereClauseQueries.get('userId')
+
+  if (userIdFromURL && userIdFromURL !== userId) {
+    /**
+     * if userId is not the same as the one in the URL, we throw an unauthorized error.
+     */
+    throw statusToError({
+      status: 401,
+      message: 'unauthorized',
+    })
+  }
+
   const response = await masterDataClient.getDocuments(
     ctx,
     schemaName,
@@ -13,7 +47,21 @@ export async function receiveDocuments(ctx: Context, next: () => Promise<any>) {
 
   ctx.status = 200
   ctx.set('Cache-Control', 'no-cache')
-  ctx.body = response
 
-  await next()
+  if (schemaName === 'returnRequests' || schemaName === 'returnProducts') {
+    const productMatchedUserId = response.filter(
+      (product: ReturnRequests | ProductRequests) => {
+        /**
+         * return only the products that match the userId
+         */
+        return product.userId && product.userId === userId
+      }
+    )
+
+    ctx.body = productMatchedUserId
+
+    return
+  }
+
+  ctx.body = response
 }

--- a/node/middlewares/receiveDocuments.ts
+++ b/node/middlewares/receiveDocuments.ts
@@ -24,7 +24,23 @@ export async function receiveDocuments(ctx: Context) {
 
   const { schemaName, whereClause, type } = ctx.vtex.route.params
 
-  const { userId } = state
+  const { userId, isAdmin } = state
+
+  if (isAdmin) {
+    /**
+     * here we can use the adminUserAuthToken, so we can get the data from the admin account. 
+     */
+    ctx.status = 200
+    ctx.set('Cache-Control', 'no-cache')
+    const adminResponse = await masterDataClient.getDocuments(
+      ctx,
+      schemaName,
+      type,
+      whereClause
+    )
+    ctx.body = adminResponse
+    return
+  }
   const whereClauseQueries = new URLSearchParams(whereClause as string)
 
   const userIdFromURL = whereClauseQueries.get('userId')

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,4 +1,35 @@
-import { deleteReturnRequest } from './deleteReturnRequest'
-import { createReturnRequest } from './createReturnRequest'
+import { deleteReturnRequest as deleteReturnRequestResolver } from './deleteReturnRequest'
+import { createReturnRequest as createReturnRequestResolver } from './createReturnRequest'
+import { getProfileEmailAndId } from '../middlewares/getProfileEmailAndId'
 
-export const mutations = { deleteReturnRequest, createReturnRequest }
+type DeleteReturnRequestParameters = Parameters<
+  typeof deleteReturnRequestResolver
+>
+type CreateReturnRequestParameters = Parameters<
+  typeof createReturnRequestResolver
+>
+
+const deleteReturnRequest = async (...args: DeleteReturnRequestParameters) => {
+  const ctx: Context = args[2]
+
+  await getProfileEmailAndId(ctx, () => {
+    return Promise.resolve()
+  })
+
+  return await deleteReturnRequestResolver(...args)
+}
+
+const createReturnRequest = async (...args: CreateReturnRequestParameters) => {
+  const ctx: Context = args[2]
+
+  await getProfileEmailAndId(ctx, () => {
+    return Promise.resolve()
+  })
+
+  return await createReturnRequestResolver(...args)
+}
+
+export const mutations = {
+  deleteReturnRequest,
+  createReturnRequest,
+}

--- a/node/utils/statusToError.ts
+++ b/node/utils/statusToError.ts
@@ -1,7 +1,7 @@
 import { AuthenticationError, ForbiddenError, UserInputError } from '@vtex/api'
 
 type StatusToError = {
-  status: number
+  status: 401 | 403 | 400
   message: string
 }
 

--- a/node/utils/statusToError.ts
+++ b/node/utils/statusToError.ts
@@ -1,0 +1,28 @@
+import { AuthenticationError, ForbiddenError, UserInputError } from '@vtex/api'
+
+type StatusToError = {
+  status: number
+  message: string
+}
+
+export function statusToError(response: Required<StatusToError>): Error {
+  if (!response) {
+    throw new Error('statusToError: response is required')
+  }
+
+  const { status, message } = response
+
+  if (status === 401) {
+    throw new AuthenticationError(message)
+  }
+
+  if (status === 403) {
+    throw new ForbiddenError(message)
+  }
+
+  if (status === 400) {
+    throw new UserInputError(message)
+  }
+
+  throw new Error(message)
+}


### PR DESCRIPTION
#### What problem is this solving?

In `return-app` there is no validation in the backend, so anyone by using POSTMAN application or even a regualr browser can access all the data (orders and/or products) that belongs to the other users, which is a very security risk.

This PR contains a middleware that validate the request sent:
---
- Verify and return only the order that belongs to the logged-in user.
- Verify and return only the products being returned belongs to the logged-in user.
   

**In the Web side, you have to have an account in yamamayqa to test the feature. none logged-in users should get 401 unauthrized status** 


**Store:**
Go to the store, create an Account or you can use an exiting account. Go browse the catalog, add something to your cart, place the order via the checkout, wait a couple of minutes, and then access the store’s My Account page, there you will see that you’ll have a list of available orders to be returned, so in that list we call [This](https://validateorderandproducts--yamamayqa.myvtex.com/returns/getDocuments/returnRequests/request/userId=a5bb44d4-f5fe-45a0-93ad-2181b3882622) API so if you are using the same account that belongs to the `userId` then you can the list of the return requests, also to get all the details about the spasicific item you can access [This](https://validateorderandproducts--yamamayqa.myvtex.com/returns/getDocuments/returnRequests/request/id=2f678f00-8a86-11ec-835d-12e2f65dc199) API


You can get all orders `getOrders` API here is the api call [This](https://validateorderandproducts--yamamayqa.myvtex.com/returns/getOrders/clientEmail=asem@qaffaf.com) API even if you pass diffrent email in `clientEmail` in the query string to the API it will returns only the orders that blongs to the logged-in user. note the query string `all` will retuns only the logged-in user's orders only.

For get one order `getOrder` API you can use this [link](https://validateorderandproducts--yamamayqa.myvtex.com/returns/getOrder/1202531641246-01) it will returns only the order that belongs only to the logged-in user. 
 
<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://validateorderandproducts--yamamayqa.myvtex.com/)

#### Screenshots or example usage:


**Client:**
this is my return list, with status.
<img width="1728" alt="Screen Shot 2022-02-02 at 3 51 56 PM" src="https://user-images.githubusercontent.com/51743718/152182301-aad61189-937c-4671-b16a-fe60f9d78d92.png">



<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![SlimyRegularGermanspaniel-size_restricted](https://user-images.githubusercontent.com/51743718/156796373-bcf26c34-a551-4700-ad0c-6df3efb2f8c7.gif)

