### PR TITLE
Hot fix/order rma mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Mismatch between products returned and order id when an order takes too long to resolve (e.g. due to slow internet) when a store user is selecting an order to be returned.
+
+### Added
+- Error handler for middlewares
 
 ## [2.19.0] - 2022-02-28
 ### Changed 

--- a/react/store/MyReturnsPageAdd.tsx
+++ b/react/store/MyReturnsPageAdd.tsx
@@ -269,7 +269,7 @@ class MyReturnsPageAdd extends Component<Props, State> {
   }
 
   selectOrder(order) {
-    this.prepareOrderData(order, this.state.settings, false)
+    this.prepareOrderData(order, this.state.settings, false, true)
     if (order.shippingData.address) {
       const complement =
         order.shippingData.address.complement !== null
@@ -307,7 +307,8 @@ class MyReturnsPageAdd extends Component<Props, State> {
   prepareOrderData = (
     order: any,
     settings: any,
-    updateEligibleOrders: boolean
+    updateEligibleOrders: boolean,
+    isSelectingOrder = false
   ) => {
     const thisOrder = order
 
@@ -449,8 +450,19 @@ class MyReturnsPageAdd extends Component<Props, State> {
         return { previousOrders, products }
       })
       .then(({ previousOrders, products }) => {
+        /**
+         * This check is prevent setting the products that will be returned
+         * during componentDidMount. Since this method is being called inside a
+         * loop, any order that takes longer to resolve in the initial setup will
+         * overwrite the products if user has already selected an order to view.
+         */
+        if (isSelectingOrder) {
+          this.setState({
+            orderProducts: products,
+          })
+        }
+
         this.setState({
-          orderProducts: products,
           eligibleOrders: previousOrders,
         })
 


### PR DESCRIPTION
#### What problem is this solving?

This is a hot fix trying to avoid the mismatch between products returned and the order id associated to them. In the investigation, I noticed that if an order takes too long to resolve when the app is listing all orders available to be returned, when it's done, it will overwrite the products been seeing by the user if they have already selected an order. It can be seen in the video below. The order [1216000039663-01](https://vtexspain.myvtex.com/admin/checkout/#/orders/1216000039663-01?orderBy=creationDate,desc&page=1&q=1216000039663-01&f_creationDate=creationDate:%5B2021-09-08T22:00:00.000Z%20TO%202022-03-09T22:59:59.999Z%5D) has a Star War figure as product, but it show a sun glasses as the product to be returned.

https://user-images.githubusercontent.com/38737958/157684712-8a4a700d-a0e4-43e0-a358-237acdf6c908.mp4

![Screen Shot 2022-03-10 at 5 22 48 PM](https://user-images.githubusercontent.com/38737958/157708056-2031c612-aa10-4079-b539-ca766bb38d80.png)

The code now doesn't set state for the products when it's preparing the list of order to be displayed, only when user has selected a order to see it.
