### PR TITLE
V3 store settings provider

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -104,6 +104,8 @@
   "store/return-app.return-order-details.error.order-not-found": "Order not found",
   "store/return-app.return-order-details.error.forbidden": "You don't have access to this order",
   "store/return-app.return-order-details.error.unknown": "Something failed, please try again.",
+  "store/return-app.return-order-details.setting-provider.error.retry-action": "Try again",
+  "store/return-app.return-order-details.setting-provider.error": "There was an error loading app settings.",
   "returns.addReturn": "Add a new return form",
   "returns.pageTitle": "My requests",
   "returns.total": "total",

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,6 +104,8 @@
   "store/return-app.return-order-details.error.order-not-found": "Order not found",
   "store/return-app.return-order-details.error.forbidden": "You don't have access to this order",
   "store/return-app.return-order-details.error.unknown": "Something failed, please try again.",
+  "store/return-app.return-order-details.setting-provider.error.retry-action": "Try again",
+  "store/return-app.return-order-details.setting-provider.error": "There was an error loading app settings.",
   "returns.addReturn": "Add a new return form",
   "returns.pageTitle": "My requests",
   "returns.total": "total",

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.0.0-beta.5/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650664444/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.0.0-beta.5/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650664444/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.0.0-beta.5/public/@types/vtex.return-app#a75ed86ae11540425c919504c6d3f7bbb0dadc54"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650664444/public/@types/vtex.return-app#2f82577747418a1dad1c33fbf77eaf719b6c9cb2"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/StoreReturnApp.ts
+++ b/react/StoreReturnApp.ts
@@ -1,0 +1,3 @@
+import StoreReturnAppRouter from './store/StoreReturnAppRouter'
+
+export default StoreReturnAppRouter

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.0.0-beta.5/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650664444/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/store/StoreMyReturnsAdd.ts
+++ b/react/store/StoreMyReturnsAdd.ts
@@ -1,2 +1,2 @@
 export { OrdersAvailableToRMA } from './createNewRMA/OrdersAvailableToRMA'
-export { OrderToRMADetails } from './createNewRMA/OrderToRMADetails'
+export { OrderDetails } from './createNewRMA/OrderToRMADetails'

--- a/react/store/StoreReturnAppRouter.tsx
+++ b/react/store/StoreReturnAppRouter.tsx
@@ -3,7 +3,7 @@ import { Route, Switch } from 'vtex.my-account-commons/Router'
 
 import { StoreMyReturnsPageWrapper } from './StoreMyReturnsPage'
 import { StoreMyReturnsDetailsWrapper } from './StoreMyReturnsDetails'
-import { OrdersAvailableToRMA, OrderToRMADetails } from './StoreMyReturnsAdd'
+import { OrdersAvailableToRMA, OrderDetails } from './StoreMyReturnsAdd'
 
 export const AppRouter = () => {
   return (
@@ -15,11 +15,7 @@ export const AppRouter = () => {
         component={StoreMyReturnsDetailsWrapper}
       />
       <Route exact path="/my-returns/add" component={OrdersAvailableToRMA} />
-      <Route
-        exact
-        path="/my-returns/add/:orderId"
-        component={OrderToRMADetails}
-      />
+      <Route exact path="/my-returns/add/:orderId" component={OrderDetails} />
     </Switch>
   )
 }

--- a/react/store/StoreReturnAppRouter.tsx
+++ b/react/store/StoreReturnAppRouter.tsx
@@ -1,12 +1,9 @@
 import React from 'react'
 import { Route, Switch } from 'vtex.my-account-commons/Router'
 
-import { StoreMyReturnsPageWrapper } from './store/StoreMyReturnsPage'
-import { StoreMyReturnsDetailsWrapper } from './store/StoreMyReturnsDetails'
-import {
-  OrdersAvailableToRMA,
-  OrderToRMADetails,
-} from './store/StoreMyReturnsAdd'
+import { StoreMyReturnsPageWrapper } from './StoreMyReturnsPage'
+import { StoreMyReturnsDetailsWrapper } from './StoreMyReturnsDetails'
+import { OrdersAvailableToRMA, OrderToRMADetails } from './StoreMyReturnsAdd'
 
 export const AppRouter = () => {
   return (

--- a/react/store/createNewRMA/OrderToRMADetails.tsx
+++ b/react/store/createNewRMA/OrderToRMADetails.tsx
@@ -14,15 +14,14 @@ import type {
   OrderToReturnSummary,
   QueryOrderToReturnSummaryArgs,
   OrderToReturnValidation,
-  ReturnAppSettings,
 } from 'vtex.return-app'
 
 import ORDER_TO_RETURN_SUMMARY from './graphql/getOrderToReturnSummary.gql'
-import RETURN_APP_SETTINGS from './graphql/getAppSettings.gql'
 import { ORDER_TO_RETURN_VALIDATON } from '../utils/constants'
 import { availableProductsToReturn } from '../utils/filterProductsToReturn'
 import { RenderConditionDropdown } from './components/RenderConditionDropdown'
 import { RenderReasonDropdown } from './components/RenderReasonDropdown'
+import { StoreSettingsPovider } from '../provider/StoreSettingsProvider'
 
 const { ORDER_NOT_INVOICED, OUT_OF_MAX_DAYS } = ORDER_TO_RETURN_VALIDATON
 
@@ -101,17 +100,6 @@ export const OrderToRMADetails = (
     skip: !orderId,
     onError: (error) => setErrorCase(getErrorCode(error)),
   })
-
-  const {
-    data: settings,
-    loading: loadingSettings,
-    error: errorSettings,
-  } = useQuery<{
-    returnAppSettings: ReturnAppSettings
-  }>(RETURN_APP_SETTINGS)
-
-  // eslint-disable-next-line no-console
-  console.log(settings, loadingSettings, errorSettings)
 
   useEffect(() => {
     if (data) {
@@ -224,7 +212,6 @@ export const OrderToRMADetails = (
           return (
             <RenderReasonDropdown
               id={rowData.id}
-              settings={settings}
               isExcluded={rowData.isExcluded}
               handleReason={handleReason}
               reason={reason}
@@ -296,5 +283,15 @@ export const OrderToRMADetails = (
         ]}
       />
     </PageBlock>
+  )
+}
+
+export const OrderDetails = (
+  props: RouteComponentProps<{ orderId: string }>
+) => {
+  return (
+    <StoreSettingsPovider>
+      <OrderToRMADetails {...props} />
+    </StoreSettingsPovider>
   )
 }

--- a/react/store/createNewRMA/components/RenderReasonDropdown.tsx
+++ b/react/store/createNewRMA/components/RenderReasonDropdown.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { useIntl, defineMessages } from 'react-intl'
 import { Dropdown } from 'vtex.styleguide'
 
+import { useStoreSettings } from '../../hooks/useStoreSettings'
+
 const messages = defineMessages({
   reasonAccidentalOrder: {
     id: 'store/return-app.return-order-details.dropdown-reasons.accidental-order',
@@ -54,13 +56,14 @@ const messages = defineMessages({
 })
 
 export const RenderReasonDropdown = ({
-  settings,
   reason,
   handleReason,
   id,
   isExcluded,
 }) => {
   const { formatMessage } = useIntl()
+
+  const { data: settings } = useStoreSettings()
 
   const reasonOptions = [
     {
@@ -121,7 +124,7 @@ export const RenderReasonDropdown = ({
     },
   ]
 
-  if (settings?.returnAppSettings.options?.enableOtherOptionSelection) {
+  if (settings?.options?.enableOtherOptionSelection) {
     reasonOptions.push({
       value: 'Other reason',
       label: formatMessage(messages.reasonOtherReason),

--- a/react/store/graphql/getStoreSettings.gql
+++ b/react/store/graphql/getStoreSettings.gql
@@ -1,4 +1,4 @@
-query appSettings {
+query storeAppSettings {
   returnAppSettings @context(provider: "vtex.return-app") {
     termsUrl
     customReturnReasons {

--- a/react/store/hooks/useStoreSettings.ts
+++ b/react/store/hooks/useStoreSettings.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react'
+
+import { StoreSettingsContext } from '../provider/StoreSettingsProvider'
+
+export const useStoreSettings = () => useContext(StoreSettingsContext)

--- a/react/store/provider/StoreSettingsProvider.tsx
+++ b/react/store/provider/StoreSettingsProvider.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import React, { createContext, useState } from 'react'
 import { useQuery } from 'react-apollo'
+import { FormattedMessage } from 'react-intl'
 import type { ReturnAppSettings } from 'vtex.return-app'
 import { Alert } from 'vtex.styleguide'
 
@@ -41,11 +42,13 @@ export const StoreSettingsPovider: FC = ({ children }) => {
         <Alert
           type="error"
           action={{
-            label: 'Recarregar',
+            label: (
+              <FormattedMessage id="store/return-app.return-order-details.setting-provider.error.retry-action" />
+            ),
             onClick: () => handleRefetching(),
           }}
         >
-          There was an error loading app settings. Please refresh the page
+          <FormattedMessage id="store/return-app.return-order-details.setting-provider.error" />
         </Alert>
       ) : (
         children

--- a/react/store/provider/StoreSettingsProvider.tsx
+++ b/react/store/provider/StoreSettingsProvider.tsx
@@ -1,0 +1,55 @@
+import type { FC } from 'react'
+import React, { createContext, useState } from 'react'
+import { useQuery } from 'react-apollo'
+import type { ReturnAppSettings } from 'vtex.return-app'
+import { Alert } from 'vtex.styleguide'
+
+import STORE_SETTING from '../graphql/getStoreSettings.gql'
+
+interface SettingsContextInterface {
+  data?: ReturnAppSettings
+  loading: boolean
+}
+
+export const StoreSettingsContext = createContext<SettingsContextInterface>(
+  {} as SettingsContextInterface
+)
+
+export const StoreSettingsPovider: FC = ({ children }) => {
+  const { data, loading, error, refetch } =
+    useQuery<{ returnAppSettings: ReturnAppSettings }>(STORE_SETTING)
+
+  const [refetching, setRefetching] = useState(false)
+
+  const handleRefetching = async () => {
+    setRefetching(true)
+
+    try {
+      await refetch()
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setRefetching(false)
+    }
+  }
+
+  return (
+    <StoreSettingsContext.Provider
+      value={{ data: data?.returnAppSettings, loading }}
+    >
+      {error && !refetching ? (
+        <Alert
+          type="error"
+          action={{
+            label: 'Recarregar',
+            onClick: () => handleRefetching(),
+          }}
+        >
+          There was an error loading app settings. Please refresh the page
+        </Alert>
+      ) : (
+        children
+      )}
+    </StoreSettingsContext.Provider>
+  )
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.0.0-beta.5/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650664444/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.0.0-beta.5/public/@types/vtex.return-app#a75ed86ae11540425c919504c6d3f7bbb0dadc54"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650664444/public/@types/vtex.return-app#2f82577747418a1dad1c33fbf77eaf719b6c9cb2"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -3,6 +3,6 @@
     "component": "StoreMyReturnsLink"
   },
   "my-account-link.my-returns-app": {
-    "component": "StoreReturnAppRouter"
+    "component": "StoreReturnApp"
   }
 }


### PR DESCRIPTION
This PR adds a custom hook `useStoreSettings` that allows any child component of `OrderToRMADetails` to read the app settings. It will  be useful to avoid prop drilling or fetching it in every single component that will use settings to create the UI.