### PR TITLE
Feat: Add property to know if the refund can be done usning credit card

### DIFF
--- a/graphql/types/OrderToReturn.graphql
+++ b/graphql/types/OrderToReturn.graphql
@@ -22,6 +22,7 @@ type OrderToReturnSummary {
   excludedItems: [excludedItem!]!
   clientProfileData: ClientProfileData!
   shippingData: ShippingData!
+  paymentData: PaymentData!
 }
 
 type Pagination {
@@ -81,4 +82,8 @@ type ShippingData {
   country: String!
   zipCode: String!
   addressType: AddressType!
+}
+
+type PaymentData {
+  canRefundCard: Boolean!
 }

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650976749/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,6 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app",
+    "vtex.return-app": "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/utils/createOrdersToReturnSummary.ts
+++ b/node/utils/createOrdersToReturnSummary.ts
@@ -103,5 +103,10 @@ export const createOrdersToReturnSummary = (
       email
     ),
     shippingData: transformShippingData(order.shippingData),
+    paymentData: {
+      canRefundCard: order.paymentData.transactions.some((transactions) =>
+        transactions.payments.some((transaction) => transaction.lastDigits)
+      ),
+    },
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,10 +6155,6 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app":
-  version "3.0.0-beta.5"
-  resolved "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app#313b9fcb6a97cef77bef3009f52b2a6f576d38b4"
-
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql#ca31214db7b9c3522ae45701732ea79022674ef8"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5614,7 +5614,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650976749/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650976749/public/@types/vtex.return-app#041876a4f0aca84f1902b42b4e875a58f7900843"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app#e031f7c679caeb3c07bfa22d09f6a4b628e717d1"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app":
+"vtex.return-app@https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app#e031f7c679caeb3c07bfa22d09f6a4b628e717d1"
+  resolved "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app#313b9fcb6a97cef77bef3009f52b2a6f576d38b4"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650976749/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,6 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app",
+    "vtex.return-app": "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/store/createReturnRequest/ReturnDetailsContainer.tsx
+++ b/react/store/createReturnRequest/ReturnDetailsContainer.tsx
@@ -107,6 +107,7 @@ export const CreateReturnRequest = (props: RouteProps) => {
           onPageChange={handlePageChange}
           items={items}
           creationDate={data?.orderToReturnSummary?.creationDate}
+          canRefundCard={data?.orderToReturnSummary?.paymentData.canRefundCard}
         />
       ) : null}
       {page === 'submit-form' ? (

--- a/react/store/createReturnRequest/components/PaymentMethods.tsx
+++ b/react/store/createReturnRequest/components/PaymentMethods.tsx
@@ -88,8 +88,6 @@ export const PaymentMethods = ({ canRefundCard }: Props) => {
     const { bank, card, giftCard } = allowedPaymentTypes
     const output: PaymentMethodsOptions[] = []
 
-    // eslint-disable-next-line no-console
-    console.log({ canRefundCard })
     if (card && canRefundCard) {
       output.push({
         value: 'card',

--- a/react/store/createReturnRequest/components/PaymentMethods.tsx
+++ b/react/store/createReturnRequest/components/PaymentMethods.tsx
@@ -11,6 +11,10 @@ import { Input, RadioGroup } from 'vtex.styleguide'
 import { useStoreSettings } from '../../hooks/useStoreSettings'
 import { useReturnRequest } from '../../hooks/useReturnRequest'
 
+interface Props {
+  canRefundCard?: boolean
+}
+
 type PaymentMethodsOptions = {
   value: keyof PaymentType
   label: React.ReactElement
@@ -23,7 +27,7 @@ const messages = defineMessages({
   },
 })
 
-export const PaymentMethods = () => {
+export const PaymentMethods = ({ canRefundCard }: Props) => {
   const { formatMessage } = useIntl()
 
   const { data } = useStoreSettings()
@@ -84,7 +88,9 @@ export const PaymentMethods = () => {
     const { bank, card, giftCard } = allowedPaymentTypes
     const output: PaymentMethodsOptions[] = []
 
-    if (card) {
+    // eslint-disable-next-line no-console
+    console.log({ canRefundCard })
+    if (card && canRefundCard) {
       output.push({
         value: 'card',
         label: (

--- a/react/store/createReturnRequest/components/ReturnDetails.tsx
+++ b/react/store/createReturnRequest/components/ReturnDetails.tsx
@@ -15,6 +15,7 @@ interface Props {
   onPageChange: (page: Page) => void
   items: ItemToReturn[]
   creationDate?: string
+  canRefundCard?: boolean
 }
 
 export const ReturnDetails = (
@@ -27,6 +28,7 @@ export const ReturnDetails = (
     onPageChange,
     items,
     creationDate,
+    canRefundCard,
   } = props
 
   const {
@@ -79,7 +81,7 @@ export const ReturnDetails = (
         <AddressDetails />
         <UserCommentDetails />
       </div>
-      <PaymentMethods />
+      <PaymentMethods canRefundCard={canRefundCard} />
       <TermsAndConditions />
       {/* TODO INTL */}
       <button onClick={handleFieldsValidation}>Next</button>

--- a/react/store/createReturnRequest/graphql/getOrderToReturnSummary.gql
+++ b/react/store/createReturnRequest/graphql/getOrderToReturnSummary.gql
@@ -32,5 +32,8 @@ query orderToReturnSummary($orderId: ID!) {
       zipCode
       addressType
     }
+    paymentData {
+      canRefundCard
+    }
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,10 +5202,6 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app":
-  version "3.0.0-beta.5"
-  resolved "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app#313b9fcb6a97cef77bef3009f52b2a6f576d38b4"
-
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql#ca31214db7b9c3522ae45701732ea79022674ef8"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app":
+"vtex.return-app@https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app#e031f7c679caeb3c07bfa22d09f6a4b628e717d1"
+  resolved "https://v3rmacardflag--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651584486/public/@types/vtex.return-app#313b9fcb6a97cef77bef3009f52b2a6f576d38b4"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650976749/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1650976749/public/@types/vtex.return-app#041876a4f0aca84f1902b42b4e875a58f7900843"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651567822/public/@types/vtex.return-app#e031f7c679caeb3c07bfa22d09f6a4b628e717d1"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"


### PR DESCRIPTION
This code brings a new flag on the `OrderToReturnSummary` resolver to show if the order can be refunded using card or not - it should be only possible to refund card if the payment was made using a card.

### How to test:

In this [workspace](https://v3rmacardflag--powerplanet.myvtex.com/admin/graphql-ide) select the return app in the GraphQL ide.

The query below will bring the result for the new flag. The first order, placed using credit card, should return `true`.  The second one, placed with promissory, should return false.

```
query orderOne {
  orderToReturnSummary(orderId: "1229173257363-01") {
    paymentData {
      canRefundCard
    }
  }
}

query orderTwo {
  orderToReturnSummary(orderId: "1224161013423-01") {
    paymentData {
      canRefundCard
    }
  }
}
```