### PR TITLE
refactor: move sendEmail to avoid sending email if something failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.19.4] - 2022-05-04
+
+### Refactor
+
+- Move sendEmail promise on `createReturnRequest.ts` resolver to avoid sending an email when the request failed.
+
 ## [2.19.4] - 2022-05-02
 
 ## [2.19.3] - 2022-03-25

--- a/node/resolvers/createReturnRequest.ts
+++ b/node/resolvers/createReturnRequest.ts
@@ -81,20 +81,6 @@ export const createReturnRequest = async (
 
       documentIdCollection.push(productReturnId)
     }
-
-    await returnApp.sendMail(ctx, {
-      TemplateName: 'oms-return-request',
-      applicationName: 'email',
-      logEvidence: false,
-      jsonData: {
-        data: { ...rmaRequestFields, DocumentId },
-        products: returnedItems.map((item) => ({
-          name: item.skuName,
-          selectedQuantity: item.quantity,
-          sellingPrice: item.unitPrice,
-        })),
-      },
-    })
   } catch (e) {
     logger.error({
       message: `Error creating return request ${DocumentId} for order id ${orderId}`,
@@ -114,6 +100,20 @@ export const createReturnRequest = async (
 
     throw new Error(e)
   }
+
+  await returnApp.sendMail(ctx, {
+    TemplateName: 'oms-return-request',
+    applicationName: 'email',
+    logEvidence: false,
+    jsonData: {
+      data: { ...rmaRequestFields, DocumentId },
+      products: returnedItems.map((item) => ({
+        name: item.skuName,
+        selectedQuantity: item.quantity,
+        sellingPrice: item.unitPrice,
+      })),
+    },
+  })
 
   return { returnRequestId: DocumentId }
 }


### PR DESCRIPTION
What is the purpose of this PR?
Move sendEmail promise outside of the logic of creating a return request to avoid sending an email if something fails.

How to test it?
If the return request is successful:
Email sent
![return_ok](https://user-images.githubusercontent.com/96049132/166631627-e89be83f-ee37-4b06-892e-63b8f97ae735.gif)

If the return request failed (I threw an error inside the try block):
No email sent
![failed_request](https://user-images.githubusercontent.com/96049132/166631753-6a55ff71-f4b2-451d-9c5a-6614b77d27f5.gif)
 
