### PR TITLE
Get rma resolver

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -11,6 +11,12 @@ type Query {
   returnRequest(requestId: ID!): ReturnRequestResponse
     @withUserProfile
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
+  returnRequestList(
+    filter: ReturnRequestFilters
+    page: Int!
+  ): ReturnRequestList
+    @withUserProfile
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
 }
 
 type Mutation {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -8,6 +8,9 @@ type Query {
   orderToReturnSummary(orderId: ID!): OrderToReturnSummary
     @withUserProfile
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
+  returnRequest(requestId: ID!): ReturnRequestResponse
+    @withUserProfile
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
 }
 
 type Mutation {

--- a/graphql/types/ReturnRequest.graphql
+++ b/graphql/types/ReturnRequest.graphql
@@ -63,3 +63,97 @@ enum RefundPaymentMethod {
   giftCard
   sameAsPurchase
 }
+
+type ReturnRequestResponse {
+  id: ID!
+  orderId: String!
+  sequenceNumber: String!
+  status: Status!
+  customerProfileData: CustomerProfileData!
+  pickupReturnData: PickupReturnData!
+  refundPaymentData: RefundPaymentData!
+  items: [ReturnRequestItem!]!
+  dateSubmitted: String!
+  createdIn: String!
+  userComment: String
+  refundData: RefundData
+  refundStatusData: [RefundStatusData!]!
+}
+
+enum Status {
+  new
+  processing
+  pickedUpFromClient
+  pendingVerification
+  packageVerified
+  amountRefunded
+  denied
+}
+
+type CustomerProfileData {
+  userId: String!
+  name: String!
+  email: String!
+  phoneNumber: String!
+}
+
+type PickupReturnData {
+  addressId: String!
+  address: String!
+  city: String!
+  state: String!
+  country: String!
+  zipCode: String!
+  addressType: AddressType!
+  returnLabel: String
+}
+
+type RefundPaymentData {
+  refundPaymentMethod: RefundPaymentMethod!
+  iban: String
+  accountHolderName: String
+}
+
+type ReturnRequestItem {
+  orderItemIndex: Int!
+  quantity: Int!
+  verifiedItems: Int
+  condition: ItemCondition!
+  returnReason: ReturnReason!
+}
+
+type ReturnReason {
+  reason: String!
+  otherReason: String
+}
+
+type RefundData {
+  invoiceNumber: String!
+  invoiceValue: String!
+  refundedItemsValue: Int!
+  refundedShippingValue: Int!
+  giftCard: GiftCard
+  Items: [RefundItem!]!
+}
+
+type GiftCard {
+  id: String
+  code: String
+}
+
+type RefundItem {
+  orderItemIndex: Int!
+  quantity: Int!
+  restockFee: Int
+}
+
+type RefundStatusData {
+  status: Status!
+  submittedBy: String!
+  comment: RefundStatusComment
+}
+
+type RefundStatusComment {
+  value: String
+  visibleForCustomer: Boolean
+}

--- a/graphql/types/ReturnRequest.graphql
+++ b/graphql/types/ReturnRequest.graphql
@@ -166,8 +166,8 @@ input ReturnRequestFilters {
 }
 
 input DateRangeInput {
-  from: String
-  to: String
+  from: String!
+  to: String!
 }
 
 type ReturnRequestList {

--- a/graphql/types/ReturnRequest.graphql
+++ b/graphql/types/ReturnRequest.graphql
@@ -68,14 +68,14 @@ type ReturnRequestResponse {
   id: ID!
   orderId: String!
   sequenceNumber: String!
+  createdIn: String!
   status: Status!
+  dateSubmitted: String!
+  userComment: String
   customerProfileData: CustomerProfileData!
   pickupReturnData: PickupReturnData!
   refundPaymentData: RefundPaymentData!
   items: [ReturnRequestItem!]!
-  dateSubmitted: String!
-  createdIn: String!
-  userComment: String
   refundData: RefundData
   refundStatusData: [RefundStatusData!]!
 }

--- a/graphql/types/ReturnRequest.graphql
+++ b/graphql/types/ReturnRequest.graphql
@@ -157,3 +157,20 @@ type RefundStatusComment {
   value: String
   visibleForCustomer: Boolean
 }
+
+input ReturnRequestFilters {
+  status: Status
+  sequenceNumber: String
+  id: String
+  createdIn: DateRangeInput
+}
+
+input DateRangeInput {
+  from: String
+  to: String
+}
+
+type ReturnRequestList {
+  list: [ReturnRequestResponse]
+  paging: Pagination
+}

--- a/masterdata/returnRequest/schema.json
+++ b/masterdata/returnRequest/schema.json
@@ -215,6 +215,13 @@
     "dateSubmitted",
     "status"
   ],
-  "v-indexed": ["id", "createdIn", "orderId", "customerProfileData", "status"],
+  "v-indexed": [
+    "id",
+    "createdIn",
+    "orderId",
+    "customerProfileData",
+    "status",
+    "sequenceNumber"
+  ],
   "v-immediate-indexing": true
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -30,7 +30,7 @@ import { checkStatus } from './middlewares/api/checkStatus'
 import { updateStatus } from './middlewares/api/updateStatus'
 import { createRefund } from './middlewares/createRefund'
 import { errorHandler } from './middlewares/errorHandler'
-import { mutations, queries } from './resolvers'
+import { mutations, queries, resolvers } from './resolvers'
 import { schemaDirectives } from './directives'
 
 const TIMEOUT_MS = 5000
@@ -129,6 +129,7 @@ export default new Service<Clients, State, ParamsContext>({
   },
   graphql: {
     resolvers: {
+      ...resolvers,
       Mutation: {
         ...mutations,
       },

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651657398/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651839091/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/resolvers/ReturnRequestResponse.ts
+++ b/node/resolvers/ReturnRequestResponse.ts
@@ -1,7 +1,7 @@
 import type { ReturnRequest } from 'vtex.return-app'
 
 // This resolver allows the parent one to fetch just the root fields for a ReturnRequest.
-// In a search, it can save some kb transfering data.
+// This stategy can save some kb when transfering data, since that in a search, we don't need all the fields.
 export const ReturnRequestResponse = {
   customerProfileData: async (
     root: ReturnRequest,

--- a/node/resolvers/ReturnRequestResponse.ts
+++ b/node/resolvers/ReturnRequestResponse.ts
@@ -1,0 +1,113 @@
+import type { ReturnRequest } from 'vtex.return-app'
+
+// This resolver allows the parent one to fetch just the root fields for a ReturnRequest.
+// In a search, it can save some kb transfering data.
+export const ReturnRequestResponse = {
+  customerProfileData: async (
+    root: ReturnRequest,
+    _args: unknown,
+    ctx: Context
+  ) => {
+    const { id, customerProfileData } = root
+
+    if (customerProfileData) return customerProfileData
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { customerProfileData: customerProfile } =
+      await returnRequestClient.get(id as string, ['customerProfileData'])
+
+    return customerProfile
+  },
+  pickupReturnData: async (
+    root: ReturnRequest,
+    _args: unknown,
+    ctx: Context
+  ) => {
+    const { id, pickupReturnData } = root
+
+    if (pickupReturnData) return pickupReturnData
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { pickupReturnData: pickupData } = await returnRequestClient.get(
+      id as string,
+      ['pickupReturnData']
+    )
+
+    return pickupData
+  },
+  refundPaymentData: async (
+    root: ReturnRequest,
+    _args: unknown,
+    ctx: Context
+  ) => {
+    const { id, refundPaymentData } = root
+
+    if (refundPaymentData) return refundPaymentData
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { refundPaymentData: refundData } = await returnRequestClient.get(
+      id as string,
+      ['refundPaymentData']
+    )
+
+    return refundData
+  },
+  items: async (root: ReturnRequest, _args: unknown, ctx: Context) => {
+    const { id, items } = root
+
+    if (items) return items
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { items: itemsList } = await returnRequestClient.get(id as string, [
+      'items',
+    ])
+
+    return itemsList
+  },
+  refundData: async (root: ReturnRequest, _args: unknown, ctx: Context) => {
+    const { id, refundData } = root
+
+    if (refundData) return refundData
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { refundData: refundDataList } = await returnRequestClient.get(
+      id as string,
+      ['refundData']
+    )
+
+    return refundDataList
+  },
+  refundStatusData: async (
+    root: ReturnRequest,
+    _args: unknown,
+    ctx: Context
+  ) => {
+    const { id, refundStatusData } = root
+
+    if (refundStatusData) return refundStatusData
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { refundStatusData: refundStatusDataList } =
+      await returnRequestClient.get(id as string, ['refundStatusData'])
+
+    return refundStatusDataList
+  },
+}

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -9,6 +9,7 @@ import { ordersAvailableToReturn } from './ordersAvailableToReturn'
 import { orderToReturnSummary } from './orderToReturnSummary'
 import { returnRequest } from './returnRequest'
 import { returnRequestList } from './returnRequestList'
+import { ReturnRequestResponse } from './ReturnRequestResponse'
 
 export const mutations = {
   deleteReturnRequest,
@@ -23,3 +24,5 @@ export const queries = {
   returnRequest,
   returnRequestList,
 }
+
+export const resolvers = { ReturnRequestResponse }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -8,6 +8,7 @@ import { categoryTreeName } from './categoryTreeName'
 import { ordersAvailableToReturn } from './ordersAvailableToReturn'
 import { orderToReturnSummary } from './orderToReturnSummary'
 import { returnRequest } from './returnRequest'
+import { returnRequestList } from './returnRequestList'
 
 export const mutations = {
   deleteReturnRequest,
@@ -20,4 +21,5 @@ export const queries = {
   ordersAvailableToReturn,
   orderToReturnSummary,
   returnRequest,
+  returnRequestList,
 }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -7,6 +7,7 @@ import {
 import { categoryTreeName } from './categoryTreeName'
 import { ordersAvailableToReturn } from './ordersAvailableToReturn'
 import { orderToReturnSummary } from './orderToReturnSummary'
+import { returnRequest } from './returnRequest'
 
 export const mutations = {
   deleteReturnRequest,
@@ -18,4 +19,5 @@ export const queries = {
   categoryTreeName,
   ordersAvailableToReturn,
   orderToReturnSummary,
+  returnRequest,
 }

--- a/node/resolvers/returnRequest.ts
+++ b/node/resolvers/returnRequest.ts
@@ -1,0 +1,33 @@
+import { ForbiddenError, ResolverError } from '@vtex/api'
+import type { QueryReturnRequestArgs, ReturnRequest } from 'vtex.return-app'
+
+export const returnRequest = async (
+  _: unknown,
+  { requestId }: QueryReturnRequestArgs,
+  ctx: Context
+) => {
+  const {
+    clients: { returnRequest: returnRequestClient },
+    state: { userProfile },
+  } = ctx
+
+  const { userId, role } = userProfile
+  const userIsAdmin = role === 'admin'
+
+  const returnRequestResult = await returnRequestClient.get(requestId, ['_all'])
+
+  if (!returnRequestResult) {
+    // Code error 'E_HTTP_404' to match the one when failing to find and order by OMS
+    throw new ResolverError(`Request ${requestId} not found`, 404, 'E_HTTP_404')
+  }
+
+  const { customerProfileData } = returnRequestResult as ReturnRequest
+
+  const requestBelongsToUser = userId === customerProfileData?.userId
+
+  if (!requestBelongsToUser && !userIsAdmin) {
+    throw new ForbiddenError('User cannot access this request')
+  }
+
+  return returnRequestResult
+}

--- a/node/resolvers/returnRequestList.ts
+++ b/node/resolvers/returnRequestList.ts
@@ -59,13 +59,14 @@ export const returnRequestList = async (
   } = ctx
 
   const { page, filter } = args
-  const { userId } = userProfile
+  const { userId, role } = userProfile
 
   // vtexProduct is undefined when coming from GraphQL IDE
   const vtexProduct = header['x-vtex-product'] as 'admin' | 'store' | undefined
 
   // This is useful to apply user filter when an admin is impersonating a store user.
-  const filterUser = vtexProduct === 'store' ? userId : undefined
+  const filterUser =
+    vtexProduct === 'store' || role === 'store-user' ? userId : undefined
 
   const rmaSearchResult = await returnRequestClient.searchRaw(
     {

--- a/node/resolvers/returnRequestList.ts
+++ b/node/resolvers/returnRequestList.ts
@@ -1,0 +1,41 @@
+import type { QueryReturnRequestListArgs } from 'vtex.return-app'
+
+export const returnRequestList = async (
+  _: unknown,
+  args: QueryReturnRequestListArgs,
+  ctx: Context
+) => {
+  const {
+    clients: { returnRequest: returnRequestClient },
+  } = ctx
+
+  const rmaSearchResult = await returnRequestClient.searchRaw(
+    {
+      page: args.page,
+      pageSize: 25,
+    },
+    [
+      'id',
+      'sequenceNumber',
+      'createdIn',
+      'status',
+      'orderId',
+      'dateSubmitted',
+      'userComment',
+    ],
+    'createdIn DESC'
+  )
+
+  const { data, pagination } = rmaSearchResult
+  const { page, pageSize, total } = pagination
+
+  return {
+    list: data,
+    paging: {
+      total,
+      perPage: pageSize,
+      currentPage: page,
+      pages: Math.ceil(total / pageSize),
+    },
+  }
+}

--- a/node/resolvers/returnRequestList.ts
+++ b/node/resolvers/returnRequestList.ts
@@ -74,10 +74,10 @@ export const returnRequestList = async (
     },
     [
       'id',
+      'orderId',
       'sequenceNumber',
       'createdIn',
       'status',
-      'orderId',
       'dateSubmitted',
       'userComment',
     ],

--- a/node/resolvers/returnRequestList.ts
+++ b/node/resolvers/returnRequestList.ts
@@ -1,4 +1,51 @@
-import type { QueryReturnRequestListArgs } from 'vtex.return-app'
+import type {
+  QueryReturnRequestListArgs,
+  ReturnRequestFilters,
+  Maybe,
+} from 'vtex.return-app'
+
+const filterDate = (date: string): string => {
+  const newDate = new Date(date)
+  const day = newDate.getDate()
+  const month = newDate.getMonth() + 1
+  const year = newDate.getFullYear()
+
+  return `${year}-${month < 10 ? `0${month}` : `${month}`}-${
+    day < 10 ? `0${day}` : `${day}`
+  }`
+}
+
+const buildWhereClause = (
+  filter: Maybe<ReturnRequestFilters> | undefined,
+  userId?: string
+) => {
+  const userFilter = userId && `customerProfileData.userId = "${userId}"`
+
+  if (!filter) return userFilter
+
+  const returnFilters = Object.entries(filter)
+  const whereFilter = returnFilters.reduce((where, [key, value]) => {
+    if (!value) return where
+
+    if (where.length) {
+      where += ` AND `
+    }
+
+    if (key === 'createdIn' && typeof value !== 'string') {
+      where += `${key} between ${filterDate(value.from)} AND ${filterDate(
+        value.to
+      )}`
+
+      return where
+    }
+
+    where += `${key}=${value}`
+
+    return where
+  }, '')
+
+  return userFilter ? `${userFilter} AND ${whereFilter}` : whereFilter
+}
 
 export const returnRequestList = async (
   _: unknown,
@@ -7,11 +54,22 @@ export const returnRequestList = async (
 ) => {
   const {
     clients: { returnRequest: returnRequestClient },
+    request: { header },
+    state: { userProfile },
   } = ctx
+
+  const { page, filter } = args
+  const { userId } = userProfile
+
+  // vtexProduct is undefined when coming from GraphQL IDE
+  const vtexProduct = header['x-vtex-product'] as 'admin' | 'store' | undefined
+
+  // This is useful to apply user filter when an admin is impersonating a store user.
+  const filterUser = vtexProduct === 'store' ? userId : undefined
 
   const rmaSearchResult = await returnRequestClient.searchRaw(
     {
-      page: args.page,
+      page,
       pageSize: 25,
     },
     [
@@ -23,18 +81,19 @@ export const returnRequestList = async (
       'dateSubmitted',
       'userComment',
     ],
-    'createdIn DESC'
+    'createdIn DESC',
+    buildWhereClause(filter, filterUser)
   )
 
   const { data, pagination } = rmaSearchResult
-  const { page, pageSize, total } = pagination
+  const { page: currentPage, pageSize, total } = pagination
 
   return {
     list: data,
     paging: {
       total,
       perPage: pageSize,
-      currentPage: page,
+      currentPage,
       pages: Math.ceil(total / pageSize),
     },
   }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651657398/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651657398/public/@types/vtex.return-app#a423c308416d09f5f198b604ec4d6c26fee1a8ef"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app#07a90c1fc5a36becd29265ab3318fd52f3654acc"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app#07a90c1fc5a36becd29265ab3318fd52f3654acc"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app#0ee5fca6d77fc7d30d03316f986a92472e5b2aed"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651839091/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app#0ee5fca6d77fc7d30d03316f986a92472e5b2aed"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651839091/public/@types/vtex.return-app#9e344953d8b852ecd1cd024b31fdb22d1bebe69c"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651839091/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651657398/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app#07a90c1fc5a36becd29265ab3318fd52f3654acc"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app#0ee5fca6d77fc7d30d03316f986a92472e5b2aed"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651657398/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651657398/public/@types/vtex.return-app#a423c308416d09f5f198b604ec4d6c26fee1a8ef"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651758911/public/@types/vtex.return-app#07a90c1fc5a36becd29265ab3318fd52f3654acc"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651839091/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651769840/public/@types/vtex.return-app#0ee5fca6d77fc7d30d03316f986a92472e5b2aed"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1651839091/public/@types/vtex.return-app#9e344953d8b852ecd1cd024b31fdb22d1bebe69c"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"


### PR DESCRIPTION
This PR brings two new resolvers:

1. returnRequestList - Takes a filter as argument and uses the search to find documents on Master data.
The filters are:
- status
- sequenceNumber
- id
- createdIn (from / to - Accepts any string that can be converted to Date)
2. returnRequest - Takes a requestId as argument and use the getDocument API to find a target document.

### How to test it:

 In this [workspace](https://rmav3getrma--powerplanet.myvtex.com/admin/graphql-ide) it's possible to run the following queries:

```query Search {
  returnRequestList(page: 1, filter: {
    createdIn: {
      to: "1/1/2023"
      from: "Fri May 02 2022 14:08:16 GMT+0200 (Central European Summer Time)"
    }
  }) {
    paging {
      total
    }
    list {
      status
      customerProfileData {
        userId
      }
      pickupReturnData {
      addressId
     }
      refundPaymentData {
        refundPaymentMethod
      }
      items {
        orderItemIndex
      }
      dateSubmitted
      refundData {
        invoiceNumber
      }
      refundStatusData {
        status
      }
    }
  }
}

query Get {
  returnRequest(requestId:"7ab5082e-cbb9-11ec-835d-0eb6fb198047") {
    id
    customerProfileData {
      userId
    }
    pickupReturnData {
      addressId
    }
    refundPaymentData {
        refundPaymentMethod
    }
    items {
        orderItemIndex
    }
    dateSubmitted
    refundData {
        invoiceNumber
      }
    refundStatusData {
        status
      }
  }
}
```