### PR TITLE
feat: add messages internationalization and linebreak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+### Fixed
+
+## [2.19.4] - 2022-05-09
+
+- Internationalize message and add linebreak variable.
 
 ## [2.19.4] - 2022-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ### Fixed
 
 ## [2.19.4] - 2022-05-09

--- a/messages/context.json
+++ b/messages/context.json
@@ -64,6 +64,7 @@
   "returns.formBank": "Bank Transfer",
   "returns.formIBAN": "IBAN",
   "returns.formAccountHolder": "Beneficiary name",
+  "returns.formSameAsOrder": "Same as order",
   "returns.formAgree": "I have read and accept the {link}",
   "returns.TermsConditions": "terms and conditions",
   "returns.formExtraComment": "Additional comments",

--- a/messages/en.json
+++ b/messages/en.json
@@ -64,6 +64,7 @@
   "returns.formBank": "Bank Transfer",
   "returns.formIBAN": "IBAN",
   "returns.formAccountHolder": "Beneficiary name",
+  "returns.formSameAsOrder": "Same as order",
   "returns.formAgree": "I have read and accept the {link}",
   "returns.TermsConditions": "terms and conditions",
   "returns.formExtraComment": "Additional comments",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5539,7 +5539,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/RequestForm.tsx
+++ b/react/components/RequestForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 import React, { Component } from 'react'
-import { defineMessages, injectIntl } from 'react-intl'
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl'
 import {
   Button,
   Checkbox,
@@ -652,7 +652,12 @@ class RequestForm extends Component<Props> {
                 {formatMessage({ id: messages.formPaymentMethod.id })}
               </p>
               {settings.hidePaymentMethodSelection ? (
-                formatMessage({ id: messages.defaultPaymentMethod.id })
+                <FormattedMessage
+                  id="returns.defaultPaymentMethod"
+                  values={{
+                    linebreak: <br />,
+                  }}
+                />
               ) : (
                 <RadioGroup
                   hideBorder

--- a/react/components/RequestInformation.tsx
+++ b/react/components/RequestInformation.tsx
@@ -36,10 +36,12 @@ const messages = defineMessages({
   formSubmit: { id: 'returns.formSubmit' },
   goBack: { id: 'returns.goBack' },
   condition: { id: 'returns.condition.label' },
+  sameAsOrder: { id: 'returns.formSameAsOrder' },
 })
 
 class RequestInformation extends Component<Props> {
   componentDidMount(): void {
+    console.log(this.props.info.paymentMethod, 'props info payment')
     typeof window !== 'undefined' && window.scrollTo(0, 0)
   }
 
@@ -224,12 +226,14 @@ class RequestInformation extends Component<Props> {
               >
                 {formatMessage({ id: messages.formVoucher.id })}
               </p>
-            ) : (
+            ) : info.paymentMethod === 'sameAsOrder' ? (
               <p
                 className={`ma1 t-small c-on-base ${styles.requestInformationSelectedPayment}`}
               >
-                {info.paymentMethod}
+                {formatMessage({ id: messages.sameAsOrder.id })}
               </p>
+            ) : (
+              info.paymentMethod
             )}
           </div>
           {info.extraComment && info.extraComment !== '' && (

--- a/react/components/RequestInformation.tsx
+++ b/react/components/RequestInformation.tsx
@@ -41,7 +41,6 @@ const messages = defineMessages({
 
 class RequestInformation extends Component<Props> {
   componentDidMount(): void {
-    console.log(this.props.info.paymentMethod, 'props info payment')
     typeof window !== 'undefined' && window.scrollTo(0, 0)
   }
 


### PR DESCRIPTION
What this PR changes:
Internationalize the payment method message on `RequestInformation` and add linebreak variable to FormattedMessage on `RequestForm`.

How to test it:
[this workspace](https://fix--vtexspain.myvtex.com/account#/my-returns/add)

Linebreak example:
![Captura de Pantalla 2022-05-09 a la(s) 11 52 47](https://user-images.githubusercontent.com/96049132/167386570-99fbe63f-42aa-4141-8163-c71f671eb291.png)

Internationalized message:
![Captura de Pantalla 2022-05-09 a la(s) 11 53 21](https://user-images.githubusercontent.com/96049132/167386596-12db5378-87f7-4f7d-8959-335a929fcc45.png)

If you want to test the linebreak this is the mutation:

```
mutation Save($saveArgs: SaveArgsV2!) {
 saveV2(args: $saveArgs)
}
```

```
{
 "saveArgs": {
  "to": "it-IT",
  "messages": [
   {
    "srcLang": "en-DV",
    "srcMessage": "returns.defaultPaymentMethod",
    "context": "vtex.return-app@2.x",
    "targetMessage": "Il rimborso verrà emesso sul metodo di pagamento utilizzato per questo ordine.{linebreak}Nel caso tu abbia pagato con contrassegno inserisci il tuo codice IBAN e i dati dell'intestatario del conto nel campo 'Commenti aggiuntivi'"
  }
  ]
 }
}
```
