### PR TITLE
Refactor: Update RMA schema

### DIFF
--- a/graphql/types/ReturnRequest.graphql
+++ b/graphql/types/ReturnRequest.graphql
@@ -10,7 +10,6 @@ input ReturnRequestInput {
 input ReturnRequestItemInput {
   orderItemIndex: Int!
   quantity: Int!
-  verifiedItems: Int
   condition: ItemCondition!
   returnReason: ReturnReasonInput!
 }
@@ -117,7 +116,6 @@ type RefundPaymentData {
 type ReturnRequestItem {
   orderItemIndex: Int!
   quantity: Int!
-  verifiedItems: Int
   condition: ItemCondition!
   returnReason: ReturnReason!
 }
@@ -150,12 +148,15 @@ type RefundItem {
 type RefundStatusData {
   status: Status!
   submittedBy: String!
-  comment: RefundStatusComment
+  createdAt: String!
+  comments: [RefundStatusComment!]!
 }
 
 type RefundStatusComment {
-  value: String
+  comment: String!
+  createdAt: String!
   visibleForCustomer: Boolean
+  submittedBy: String!
 }
 
 input ReturnRequestFilters {

--- a/masterdata/returnRequest/schema.json
+++ b/masterdata/returnRequest/schema.json
@@ -111,7 +111,6 @@
         "properties": {
           "orderItemIndex": { "type": "integer", "required": true },
           "quantity": { "type": "integer", "required": true },
-          "verifiedItems": { "type": ["integer", "null"], "required": true },
           "returnReason": {
             "type": "object",
             "required": true,
@@ -180,12 +179,27 @@
         "type": "object",
         "properties": {
           "status": { "$ref": "#/$defs/status", "required": true },
-          "submittedBy": { "type": "string" },
-          "comment": {
-            "type": "object",
-            "properties": {
-              "value": { "type": "string" },
-              "visibleForCustomer": { "type": "boolean" }
+          "submittedBy": { "type": "string", "required": true },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "required": true
+          },
+          "comments": {
+            "type": "array",
+            "required": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "comment": { "type": "string", "required": true },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "required": true
+                },
+                "submittedBy": { "type": "string", "required": true },
+                "visibleForCustomer": { "type": "boolean" }
+              }
             }
           }
         }

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652107667/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/resolvers/createReturnRequest.ts
+++ b/node/resolvers/createReturnRequest.ts
@@ -84,12 +84,7 @@ export const createReturnRequest = async (
     },
     pickupReturnData,
     refundPaymentData,
-    items: items.map((item) => {
-      return {
-        ...item,
-        verifiedItems: item.verifiedItems ?? null,
-      }
-    }),
+    items,
     dateSubmitted: requestDate,
     refundData: null,
     userComment,
@@ -97,7 +92,8 @@ export const createReturnRequest = async (
       {
         status: 'new',
         submittedBy,
-        dateSubmitted: requestDate,
+        createdAt: requestDate,
+        comments: [],
       },
     ],
   })

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652107667/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652107667/public/@types/vtex.return-app#470d1877c94f94f57601491407831132cb28bd9a"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app#60dcb9df69a69d635f752ce6bd29a2a9259b0683"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/graphql/getReturnRequestDetails.gql
+++ b/react/graphql/getReturnRequestDetails.gql
@@ -28,7 +28,6 @@ query getReturnRequestDetails($requestId: ID!) {
     items {
       orderItemIndex
       quantity
-      verifiedItems
       condition
       returnReason {
         reason
@@ -53,9 +52,12 @@ query getReturnRequestDetails($requestId: ID!) {
     refundStatusData {
       status
       submittedBy
-      comment {
-        value
+      createdAt
+      comments {
+        comment
+        createdAt
         visibleForCustomer
+        submittedBy
       }
     }
   }

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652107667/public/@types/vtex.return-app",
+    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652107667/public/@types/vtex.return-app":
+"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652107667/public/@types/vtex.return-app#470d1877c94f94f57601491407831132cb28bd9a"
+  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app#60dcb9df69a69d635f752ce6bd29a2a9259b0683"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"


### PR DESCRIPTION
Changes in the schema:

1. Removed `verifiedItems` from `items`.
Previously, the key would be used to control if an item had been already verified (different than `null`) and how many items had been verified for that item. However, the field being `null` or `0` could lead to bugs when checking falsy values and make it difficult to understand the real meaning of the field.
Alternatively, the app can use the `RefundData` to calculate the items that have been verified. The `RefundData` object will be created when the status `packageVerified` is submitted. This way, we can calculate the items verified in the browser using the object. Also, a request with status `denied` means that all items were denied.

2. Change the way to save comments.
Previously, the request could have several objects with the same status, in case that a user added a comment for the current status. With that structure, in order to display the currently status in the UI, we would have to search the status by the submitted that to know the oldest way (and then show the date in the UI).
With the new proposed structure, a request will have only one object per status inside `RefundStatusData` and the comments will be saved inside it. This way, it will be easier to determine the comments related to a status, and the date and user that submitted the status for the first time.