### PR TITLE
V3rmavalues

### DIFF
--- a/graphql/types/ReturnRequest.graphql
+++ b/graphql/types/ReturnRequest.graphql
@@ -66,11 +66,13 @@ enum RefundPaymentMethod {
 type ReturnRequestResponse {
   id: ID!
   orderId: String!
+  refundableAmount: Int!
   sequenceNumber: String!
   createdIn: String!
   status: Status!
   dateSubmitted: String!
   userComment: String
+  refundableAmountTotals: [RefundableAmountTotal!]!
   customerProfileData: CustomerProfileData!
   pickupReturnData: PickupReturnData!
   refundPaymentData: RefundPaymentData!
@@ -118,6 +120,12 @@ type ReturnRequestItem {
   quantity: Int!
   condition: ItemCondition!
   returnReason: ReturnReason!
+  """
+  id: SKU id
+  """
+  id: String!
+  sellingPrice: Int!
+  tax: Int!
 }
 
 type ReturnReason {
@@ -175,4 +183,15 @@ input DateRangeInput {
 type ReturnRequestList {
   list: [ReturnRequestResponse!]
   paging: Pagination
+}
+
+type RefundableAmountTotal {
+  id: RefundableAmountId!
+  value: Int!
+}
+
+enum RefundableAmountId {
+  items
+  shipping
+  tax
 }

--- a/masterdata/returnRequest/schema.json
+++ b/masterdata/returnRequest/schema.json
@@ -4,7 +4,7 @@
       "type": "string",
       "required": true
     },
-    "totalReturnAmount": {
+    "refundableAmount": {
       "type": "integer",
       "required": true
     },
@@ -13,7 +13,7 @@
       "required": true
     },
     "status": { "$ref": "#/$defs/status", "required": true },
-    "returnTotals": {
+    "refundableAmountTotals": {
       "type": "array",
       "required": true,
       "items": {
@@ -110,6 +110,9 @@
         "type": "object",
         "properties": {
           "orderItemIndex": { "type": "integer", "required": true },
+          "id": { "type": "string", "required": true },
+          "sellingPrice": { "type": "integer", "required": true },
+          "tax": { "type": "integer", "required": true },
           "quantity": { "type": "integer", "required": true },
           "returnReason": {
             "type": "object",
@@ -165,8 +168,10 @@
             "type": "object",
             "properties": {
               "orderItemIndex": { "type": "integer", "required": true },
+              "id": { "type": "integer", "required": true },
+              "price": { "type": "integer", "required": true },
               "quantity": { "type": "integer", "required": true },
-              "restockFee": { "type": "integer" }
+              "restockFee": { "type": "integer", "required": true }
             }
           }
         }

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app",
+    "vtex.return-app": "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1653036446/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app",
+    "vtex.return-app": "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/resolvers/ReturnRequestResponse.ts
+++ b/node/resolvers/ReturnRequestResponse.ts
@@ -3,6 +3,24 @@ import type { ReturnRequest } from 'vtex.return-app'
 // This resolver allows the parent one to fetch just the root fields for a ReturnRequest.
 // This stategy can save some kb when transfering data, since that in a search, we don't need all the fields.
 export const ReturnRequestResponse = {
+  refundableAmount: async (
+    root: ReturnRequest,
+    _args: unknown,
+    ctx: Context
+  ) => {
+    const { id, refundableAmount } = root
+
+    if (refundableAmount) return refundableAmount
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { refundableAmount: refundableAmountValue } =
+      await returnRequestClient.get(id as string, ['refundableAmount'])
+
+    return refundableAmountValue
+  },
   customerProfileData: async (
     root: ReturnRequest,
     _args: unknown,
@@ -20,6 +38,24 @@ export const ReturnRequestResponse = {
       await returnRequestClient.get(id as string, ['customerProfileData'])
 
     return customerProfile
+  },
+  refundableAmountTotals: async (
+    root: ReturnRequest,
+    _args: unknown,
+    ctx: Context
+  ) => {
+    const { id, refundableAmountTotals } = root
+
+    if (refundableAmountTotals) return refundableAmountTotals
+
+    const {
+      clients: { returnRequest: returnRequestClient },
+    } = ctx
+
+    const { refundableAmountTotals: refundableAmountTotalsData } =
+      await returnRequestClient.get(id as string, ['refundableAmountTotals'])
+
+    return refundableAmountTotalsData
   },
   pickupReturnData: async (
     root: ReturnRequest,

--- a/node/resolvers/createReturnRequest.ts
+++ b/node/resolvers/createReturnRequest.ts
@@ -2,8 +2,7 @@ import { UserInputError } from '@vtex/api'
 import type { MutationCreateReturnRequestArgs } from 'vtex.return-app'
 
 import { createItemsToReturn } from '../utils/createItemsToReturn'
-
-// const createRefundableTotals = (itemsToReturn: ReturnRequest['items']): Record<ReturnRequest['']
+import { createRefundableTotals } from '../utils/createRefundableTotals'
 
 export const createReturnRequest = async (
   _: unknown,
@@ -69,13 +68,20 @@ export const createReturnRequest = async (
 
   const itemsToReturn = createItemsToReturn(items, orderItems)
 
+  const refundableAmountTotals = createRefundableTotals(itemsToReturn)
+
+  const refundableAmount = refundableAmountTotals.reduce(
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    (amount, cur) => amount + cur.value,
+    0
+  )
+
   const rmaDocument = await returnRequestClient.save({
     orderId,
-    // Rename field to: totalAvailableReturnAmount (on masterdata schema, then here)
-    refundableAmount: 1234,
+    refundableAmount,
     sequenceNumber,
     status: 'new',
-    refundableAmountTotals: [{ id: 'items', value: 1234 }],
+    refundableAmountTotals,
     customerProfileData: {
       userId: userProfileId,
       name: customerProfileData.name,

--- a/node/resolvers/createReturnRequest.ts
+++ b/node/resolvers/createReturnRequest.ts
@@ -60,6 +60,7 @@ export const createReturnRequest = async (
     sequence,
     clientProfileData: { userProfileId },
     items: orderItems,
+    totals,
   } = order
 
   // Possible bug here: If someone deletes a request, it can lead to a duplicated sequence number.
@@ -68,7 +69,13 @@ export const createReturnRequest = async (
 
   const itemsToReturn = createItemsToReturn(items, orderItems)
 
-  const refundableAmountTotals = createRefundableTotals(itemsToReturn)
+  // TODO: Apply the flag to return proportional shipping from admin
+  const shippingAmount = totals.find(({ id }) => id === 'Shipping')?.value ?? 0
+
+  const refundableAmountTotals = createRefundableTotals(
+    itemsToReturn,
+    shippingAmount
+  )
 
   const refundableAmount = refundableAmountTotals.reduce(
     // eslint-disable-next-line @typescript-eslint/restrict-plus-operands

--- a/node/utils/createItemsToReturn.ts
+++ b/node/utils/createItemsToReturn.ts
@@ -1,0 +1,48 @@
+import { UserInputError } from '@vtex/api'
+import type { OrderItemDetailResponse, PriceTag } from '@vtex/clients'
+import type { ReturnRequest, ReturnRequestItemInput } from 'vtex.return-app'
+
+const calculateItemTax = (
+  tax: number,
+  priceTags: PriceTag[],
+  totalQuantity: number
+): number => {
+  if (tax) return tax
+
+  const taxHubItems = priceTags.filter((priceTag) =>
+    priceTag.name.includes('TAXHUB')
+  )
+
+  if (taxHubItems.length === 0) return 0
+
+  const taxValueFromTaxHub = taxHubItems.reduce(
+    (acc, cur) => acc + cur.value,
+    0
+  )
+
+  return parseFloat((taxValueFromTaxHub / totalQuantity).toFixed(2)) * 100
+}
+
+export const createItemsToReturn = (
+  itemsToReturn: ReturnRequestItemInput[],
+  orderItems: OrderItemDetailResponse[]
+): ReturnRequest['items'] => {
+  return itemsToReturn.map((item) => {
+    const orderItem = orderItems[item.orderItemIndex]
+
+    if (!orderItem) {
+      throw new UserInputError(
+        `Item index ${item.orderItemIndex} doesn't exist on order`
+      )
+    }
+
+    const { id, sellingPrice, tax, priceTags, quantity } = orderItem
+
+    return {
+      ...item,
+      id,
+      sellingPrice,
+      tax: calculateItemTax(tax, priceTags, quantity),
+    }
+  })
+}

--- a/node/utils/createRefundableTotals.ts
+++ b/node/utils/createRefundableTotals.ts
@@ -1,7 +1,8 @@
 import type { RefundableAmountTotal, ReturnRequest } from 'vtex.return-app'
 
 export const createRefundableTotals = (
-  itemsToReturn: ReturnRequest['items']
+  itemsToReturn: ReturnRequest['items'],
+  shippingAmount: number
 ): RefundableAmountTotal[] => {
   const itemsAmount =
     itemsToReturn?.reduce((total, item) => {
@@ -21,8 +22,7 @@ export const createRefundableTotals = (
 
   const taxTotal = { id: 'tax' as const, value: taxAmount }
 
-  // TODO: Calculate shipping based on flag on admin (total or partial)
-  const shippingTotal = { id: 'shipping' as const, value: 0 }
+  const shippingTotal = { id: 'shipping' as const, value: shippingAmount }
 
   return [itemsTotal, shippingTotal, taxTotal]
 }

--- a/node/utils/createRefundableTotals.ts
+++ b/node/utils/createRefundableTotals.ts
@@ -1,18 +1,8 @@
-import type { ReturnRequest } from 'vtex.return-app'
-
-type RequiredTotals = Required<
-  Required<ReturnRequest>['refundableAmountTotals'][number]
->
-
-interface Totals {
-  [k: string]: unknown
-  id: RequiredTotals['id']
-  value: RequiredTotals['value']
-}
+import type { RefundableAmountTotal, ReturnRequest } from 'vtex.return-app'
 
 export const createRefundableTotals = (
   itemsToReturn: ReturnRequest['items']
-): Totals[] => {
+): RefundableAmountTotal[] => {
   const itemsAmount =
     itemsToReturn?.reduce((total, item) => {
       const { quantity, sellingPrice } = item

--- a/node/utils/createRefundableTotals.ts
+++ b/node/utils/createRefundableTotals.ts
@@ -1,0 +1,38 @@
+import type { ReturnRequest } from 'vtex.return-app'
+
+type RequiredTotals = Required<
+  Required<ReturnRequest>['refundableAmountTotals'][number]
+>
+
+interface Totals {
+  [k: string]: unknown
+  id: RequiredTotals['id']
+  value: RequiredTotals['value']
+}
+
+export const createRefundableTotals = (
+  itemsToReturn: ReturnRequest['items']
+): Totals[] => {
+  const itemsAmount =
+    itemsToReturn?.reduce((total, item) => {
+      const { quantity, sellingPrice } = item
+
+      return total + (quantity ?? 0) * (sellingPrice ?? 0)
+    }, 0) ?? 0
+
+  const itemsTotal = { id: 'items' as const, value: itemsAmount }
+
+  const taxAmount =
+    itemsToReturn?.reduce((total, item) => {
+      const { quantity, tax } = item
+
+      return total + (quantity ?? 0) * (tax ?? 0)
+    }, 0) ?? 0
+
+  const taxTotal = { id: 'tax' as const, value: taxAmount }
+
+  // TODO: Calculate shipping based on flag on admin (total or partial)
+  const shippingTotal = { id: 'shipping' as const, value: 0 }
+
+  return [itemsTotal, shippingTotal, taxTotal]
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app":
+"vtex.return-app@https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app#60dcb9df69a69d635f752ce6bd29a2a9259b0683"
+  resolved "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app#ec335f2830565a641f58e87ca64619c55df57d63"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app":
+"vtex.return-app@https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1653036446/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app#ec335f2830565a641f58e87ca64619c55df57d63"
+  resolved "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1653036446/public/@types/vtex.return-app#68d5bf05befa0277c434a99fe4478f898c210615"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/graphql/getReturnRequestDetails.gql
+++ b/react/graphql/getReturnRequestDetails.gql
@@ -2,10 +2,15 @@ query getReturnRequestDetails($requestId: ID!) {
   returnRequestDetails: returnRequest(requestId: $requestId) {
     id
     orderId
+    refundableAmount
     sequenceNumber
     createdIn
     status
     userComment
+    refundableAmountTotals {
+      id
+      value
+    }
     customerProfileData {
       name
       email
@@ -29,6 +34,9 @@ query getReturnRequestDetails($requestId: ID!) {
       orderItemIndex
       quantity
       condition
+      id
+      sellingPrice
+      tax
       returnReason {
         reason
         otherReason

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app",
+    "vtex.return-app": "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app",
+    "vtex.return-app": "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1653036446/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app":
+"vtex.return-app@https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652697476/public/@types/vtex.return-app#60dcb9df69a69d635f752ce6bd29a2a9259b0683"
+  resolved "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app#ec335f2830565a641f58e87ca64619c55df57d63"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app":
+"vtex.return-app@https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1653036446/public/@types/vtex.return-app":
   version "3.0.0-beta.5"
-  resolved "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1652965936/public/@types/vtex.return-app#ec335f2830565a641f58e87ca64619c55df57d63"
+  resolved "https://v3rmavalues--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.5+build1653036446/public/@types/vtex.return-app#68d5bf05befa0277c434a99fe4478f898c210615"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"


### PR DESCRIPTION
This code changes the resolver to create a new request, and calculates and brings the refundable values for it. The values are broken as `items`, `shipping`, and `tax` and every item in the request now has the `sellingPrice` and `tax`. The taxes are either from `item.tax` (from order) or calculated from the TAXHUB value (non-native tax engines). In some cases I found (unileverb2b), the value coming from the TAXHUB for every item is the total for that item (not per unit). The current implementation also follows this logic, so I handled it like that. The `item.tax` is a unit tax.

### How to test it:
This [workspace](https://v3rmavalues--powerplanet.myvtex.com/) has the branch linked. One can create a new request. When checking it's object, the amounts should be present. 