### PR TITLE
feat: add loading component to ReturnDetails

### DIFF
--- a/react/store/createReturnRequest/ReturnDetailsContainer.tsx
+++ b/react/store/createReturnRequest/ReturnDetailsContainer.tsx
@@ -16,6 +16,7 @@ import { formatItemsToReturn } from '../utils/formatItemsToReturn'
 import { setInitialPickupAddress } from '../utils/setInitialPickupAddress'
 import { getErrorCode, errorMessages } from '../utils/getErrorCode'
 import { useStoreSettings } from '../hooks/useStoreSettings'
+import { ReturnDetailsLoader } from './components/loaders/ReturnDetailsLoader'
 
 export type Page = 'form-details' | 'submit-form'
 
@@ -98,7 +99,7 @@ export const CreateReturnRequest = (props: RouteProps) => {
 
   return (
     <>
-      {page === 'form-details' ? (
+      {page === 'form-details' && !loading ? (
         <ReturnDetails
           {...props}
           onPageChange={handlePageChange}
@@ -106,7 +107,11 @@ export const CreateReturnRequest = (props: RouteProps) => {
           creationDate={data?.orderToReturnSummary?.creationDate}
           canRefundCard={data?.orderToReturnSummary?.paymentData.canRefundCard}
         />
-      ) : null}
+      ) : (
+        <ReturnDetailsLoader
+          data={{ loading, data: data?.orderToReturnSummary }}
+        />
+      )}
       {page === 'submit-form' ? (
         <ConfirmAndSubmit onPageChange={handlePageChange} items={items} />
       ) : null}

--- a/react/store/createReturnRequest/components/loaders/ReturnDetailsLoader.tsx
+++ b/react/store/createReturnRequest/components/loaders/ReturnDetailsLoader.tsx
@@ -1,0 +1,180 @@
+import React from 'react'
+import type { FunctionComponent } from 'react'
+import { SkeletonPiece, BaseLoading } from 'vtex.my-account-commons'
+import type { OrderToReturnSummary } from 'vtex.return-app'
+import { PageBlock } from 'vtex.styleguide'
+import { FormattedMessage } from 'react-intl'
+
+interface Data {
+  loading: boolean
+  data: OrderToReturnSummary | undefined
+}
+
+interface Props {
+  data: Data
+}
+
+export const ReturnDetailsLoader: FunctionComponent<Props> = ({ data }) => {
+  const headerConfig = {
+    namespace: 'vtex-account__return-details',
+    title: (
+      <FormattedMessage id="store/return-app.return-order-details.page-header.title" />
+    ),
+    titleId: 'store/return-app.request-return.page.header"',
+    backButton: {
+      titleId: 'store/return-app.return-order-details.page-header.link',
+      path: '#/my-returns/add',
+    },
+  }
+
+  return (
+    <PageBlock className="ph0 mh0 pa0 pa0-ns">
+      <BaseLoading queryData={data} headerConfig={headerConfig}>
+        <div className="mb5 w-100">
+          <div className="w-100 flex flex-row-ns ba br3 b--muted-4 flex-column">
+            <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
+              <div>
+                <div className="c-muted-2 f6">
+                  <SkeletonPiece width="40" size="3" />
+                </div>
+                <div className="w-100 mt2">
+                  <div className="f4 fw5 c-on-base">
+                    <SkeletonPiece width="70" size="3" />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
+              <div>
+                <div className="c-muted-2 f6">
+                  <SkeletonPiece width="40" size="3" />
+                </div>
+                <div className="w-100 mt2">
+                  <div className="f4 fw5 c-on-base">
+                    <SkeletonPiece width="70" size="3" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* OrderId and creationDate end */}
+        <table className="w-100">
+          <thead className="w-100 ph4 truncate overflow-x-hidden c-muted-2 f6">
+            <tr className="w-100 truncate overflow-x-hidden">
+              <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s">
+                <SkeletonPiece width="30" size="2" />
+              </th>
+              <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
+                <SkeletonPiece width="30" size="2" />
+              </th>
+              <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
+                <SkeletonPiece width="30" size="2" />
+              </th>
+              <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
+                <SkeletonPiece width="30" size="2" />
+              </th>
+              <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
+                <SkeletonPiece width="30" size="2" />
+              </th>
+              <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
+                <SkeletonPiece width="30" size="2" />
+              </th>
+            </tr>
+          </thead>
+          <tbody className="v-mid">
+            <tr>
+              <td>
+                <section className="ml3">
+                  <p className="t-body fw5 m2">
+                    <SkeletonPiece width="30" size="2" />
+                  </p>
+                  <div className="flex">
+                    <SkeletonPiece width="10" size="5" />
+                  </div>
+                </section>
+              </td>
+              <td>
+                <SkeletonPiece width="70" size="3" />
+              </td>
+              <td>
+                <SkeletonPiece width="70" size="3" />
+              </td>
+              <td>
+                <SkeletonPiece width="70" size="3" />
+              </td>
+              <td>
+                <SkeletonPiece width="70" size="3" />
+              </td>
+              <td>
+                <SkeletonPiece width="70" size="3" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        {/* TableEnd */}
+        <div className="flex-ns flex-wrap flex-row mt5">
+          {/* contactDetails */}
+          <div className="flex-ns flex-wrap flex-auto flex-column pa4">
+            <p>
+              <SkeletonPiece width="30" size="3" />
+            </p>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+          </div>
+          {/* AddressDetails */}
+          <div className="flex-ns flex-wrap flex-auto flex-column pa4">
+            <p>
+              <SkeletonPiece width="30" size="3" />
+            </p>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+            <div className="mb4">
+              <SkeletonPiece width="70" size="3" />
+            </div>
+          </div>
+          {/* UserCommentDetails */}
+          <div className="mt4 ph4">
+            <p>
+              <SkeletonPiece width="30" size="3" />
+            </p>
+            <div>
+              <SkeletonPiece width="50" size="8" />
+            </div>
+          </div>
+        </div>
+        <div className="flex-ns flex-wrap flex-auto flex-column pa4 mb6">
+          <p>
+            <SkeletonPiece width="70" size="3" />
+          </p>
+          <p>
+            <SkeletonPiece width="70" size="3" />
+          </p>
+        </div>
+        <div className="flex-ns flex-wrap flex-auto flex-column pa4">
+          <SkeletonPiece width="70" size="3" />
+        </div>
+        <div className="flex-ns flex-wrap flex-auto flex-column pa4">
+          <SkeletonPiece width="20" size="4" />
+        </div>
+      </BaseLoading>
+    </PageBlock>
+  )
+}


### PR DESCRIPTION
What this PR changes:
Add a custom loader component to `ReturnDetails`.

How to test it:
[workspace](https://skeleton--powerplanet.myvtex.com/account?__bindingAddress=www.we-demostore.com/es#/my-returns/add/1234661288883-01)
![loading](https://user-images.githubusercontent.com/96049132/170439463-858c0beb-df44-4d73-9a67-16c7f2e2d37d.gif)

PD: I couldnt achieve to make the loader 100% width because on the repo y set as 80%. @filafb do you have a workaround here?
