### PR TITLE
Extra settings apart from settings MD document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Manifest settingsSchema
+- Get settings endpoint
+- New setting 'displayConditionSelector' which hides the product's condition select
+
 ## [2.19.6] - 2022-05-26
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,18 @@
     "postreleasy": "vtex publish --verbose"
   },
   "credentialType": "absolute",
+  "settingsSchema": {
+    "title": "Return app",
+    "type": "object",
+    "properties": {
+      "displayConditionSelector": {
+        "title": "Display 'CONDITION' selector",
+        "description": "Display, in the return request, the selector for the condition of the product",
+        "type": "boolean",
+        "default": true
+      }
+    }
+  },
   "policies": [
     {
       "name": "outbound-access",

--- a/node/index.ts
+++ b/node/index.ts
@@ -25,6 +25,7 @@ import { checkStatus } from './middlewares/api/checkStatus'
 import { updateStatus } from './middlewares/api/updateStatus'
 import { createRefund } from './middlewares/createRefund'
 import { errorHandler } from './middlewares/errorHandler'
+import { getExtraSettings } from './middlewares/getExtraSettings'
 import { mutations } from './resolvers'
 
 const TIMEOUT_MS = 20000
@@ -117,6 +118,9 @@ export default new Service({
     }),
     createRefund: method({
       POST: [errorHandler, createRefund],
+    }),
+    getExtraSettings: method({
+      GET: [errorHandler, getExtraSettings],
     }),
   },
   graphql: {

--- a/node/middlewares/getExtraSettings.ts
+++ b/node/middlewares/getExtraSettings.ts
@@ -7,9 +7,6 @@ export async function getExtraSettings(ctx: Context, next: () => Promise<any>) {
   const appId = process.env.VTEX_APP_ID as string
   const settings = (await apps.getAppSettings(appId)) as Settings
 
-  console.log(appId)
-  console.log(settings)
-
   ctx.status = 200
   ctx.body = settings
 

--- a/node/middlewares/getExtraSettings.ts
+++ b/node/middlewares/getExtraSettings.ts
@@ -1,0 +1,17 @@
+/* Used to fetch settings apart from the masterdata settings document */
+export async function getExtraSettings(ctx: Context, next: () => Promise<any>) {
+  const {
+    clients: { apps },
+  } = ctx
+
+  const appId = process.env.VTEX_APP_ID as string
+  const settings = (await apps.getAppSettings(appId)) as Settings
+
+  console.log(appId)
+  console.log(settings)
+
+  ctx.status = 200
+  ctx.body = settings
+
+  await next()
+}

--- a/node/package.json
+++ b/node/package.json
@@ -17,18 +17,18 @@
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.easypost": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.easypost@0.1.1/public/@types/vtex.easypost",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
-    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account",
+    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.react-portal": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.125.0/public/@types/vtex.store",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.159.4/public/@types/vtex.store-components",
+    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources",
+    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.86.0/public/@types/vtex.store-resources",
     "vtex.store-session": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide",
-    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
+    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.11.1/public/@types/vtex.telemarketing"
   },
   "scripts": {
     "lint": "tsc --noEmit --pretty && tslint -c tslint.json --fix './**/*.ts'"

--- a/node/service.json
+++ b/node/service.json
@@ -107,6 +107,10 @@
       "path": "/returns/createRefund/:orderId",
       "public": true,
       "settingsType": "workspace"
+    },
+    "getExtraSettings": {
+      "path": "/returns/getExtraSettings",
+      "public": true
     }
   }
 }

--- a/node/typings/vtex.return-app.d.ts
+++ b/node/typings/vtex.return-app.d.ts
@@ -77,3 +77,7 @@ type ProductReturnedInput = Omit<
   | 'totalPrice'
   | 'status'
 >
+
+interface Settings {
+  displayConditionSelector: boolean
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6008,49 +6008,49 @@ verror@1.10.0:
   version "1.6.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons#3715228fb82e81e955e6a90d11e7975e72b37b2e"
 
-"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account":
-  version "1.24.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account#f1dfdcedd359e5716d30f4765181bd52a90b37d8"
+"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account":
+  version "1.25.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account#3bc46389c0aa28f4e3e2e008fe3690f5901b1f2a"
 
 "vtex.react-portal@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal":
   version "0.4.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal#781ce4b53ba576a6365306531d8be0f1ad114769"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
-  version "8.132.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime":
+  version "8.132.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components":
-  version "3.155.9"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components#3dc767937110f31a859765e7ec21a85654151622"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.159.4/public/@types/vtex.store-components":
+  version "3.159.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.159.4/public/@types/vtex.store-components#980959f4b175469ce8e2a5d725ada92ca4ed4097"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql":
-  version "2.149.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql#f0d8a098e77875e69e5ef01453ba5e76de44e4f1"
+"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
+  version "2.152.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql#ca31214db7b9c3522ae45701732ea79022674ef8"
 
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons":
   version "0.18.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons#0ee94d549aa283ce3a13ab987c13eac4fdfd1bba"
 
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources":
-  version "0.85.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources#c320bf775471cec37977bfb8af2cfccd4c857c63"
+"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.86.0/public/@types/vtex.store-resources":
+  version "0.86.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.86.0/public/@types/vtex.store-resources#f7342903c67ab8abe50f413b2ca4b845c93e4706"
 
 "vtex.store-session@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store":
-  version "2.121.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store#1401d6ee5e16ff8b52227213f05331bba94a5639"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.125.0/public/@types/vtex.store":
+  version "2.125.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.125.0/public/@types/vtex.store#2fcc423f7d8b1eaaf3eb5422afb52a91729a75e2"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide":
-  version "9.145.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide#ca64bf8408ad3eb487b0822dd68f77565c986a56"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide":
+  version "9.146.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide#66db40ca1b78ad77ce4beedabecee320e1ef2ead"
 
-"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing":
-  version "2.10.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing#13f962450036d2e8d6cf79784e55d2bf418823e0"
+"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.11.1/public/@types/vtex.telemarketing":
+  version "2.11.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.11.1/public/@types/vtex.telemarketing#747a47bc888fce4032b384338dfc45c1f3e538ce"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/react/common/fetch.tsx
+++ b/react/common/fetch.tsx
@@ -16,6 +16,7 @@ export const fetchPath = {
   getOrder: '/returns/getOrder/',
   renderTemplates: '/api/template-render/pvt/templates',
   createRefund: '/returns/createRefund/',
+  getExtraSettings: '/returns/getExtraSettings',
 }
 
 export const fetchMethod = {

--- a/react/components/ProductsTable.tsx
+++ b/react/components/ProductsTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-plus-operands */
 import type { FunctionComponent } from 'react'
 import React from 'react'
 import { FormattedCurrency } from 'vtex.format-currency'
@@ -117,13 +118,15 @@ const ProductsTable: FunctionComponent<Props> = (props) => {
                     : null}
                 </div>
 
-                <div className={`${styles.reasonStyle} ${styles.mt10}`}>
-                  <span className={styles.strongText}>
-                    {formatMessage({ id: messages.condition.id })}
-                    {': '}
-                  </span>
-                  {currentProduct.condition}{' '}
-                </div>
+                {currentProduct.condition && (
+                  <div className={`${styles.reasonStyle} ${styles.mt10}`}>
+                    <span className={styles.strongText}>
+                      {formatMessage({ id: messages.condition.id })}
+                      {': '}
+                    </span>
+                    {currentProduct.condition}{' '}
+                  </div>
+                )}
               </td>
               <td className={`${styles.tableTd} ${styles.tableReasonQty}`}>
                 {currentProduct.quantity}
@@ -173,7 +176,7 @@ const ProductsTable: FunctionComponent<Props> = (props) => {
           <td className={`${styles.tableTd}`} />
           <td className={`${styles.tableTd}`} colSpan={2}>
             <strong>
-              <FormattedCurrency value={productsValue/100} />
+              <FormattedCurrency value={productsValue / 100} />
             </strong>
           </td>
         </tr>
@@ -192,7 +195,9 @@ const ProductsTable: FunctionComponent<Props> = (props) => {
               <FormattedCurrency
                 value={product.reduce(
                   (acc, el) =>
-                    acc + (el.unitPrice / 100 + (el.tax ? el.tax : 0)) * el.goodProducts,
+                    acc +
+                    (el.unitPrice / 100 + (el.tax ? el.tax : 0)) *
+                      el.goodProducts,
                   0
                 )}
               />

--- a/react/components/RequestForm.tsx
+++ b/react/components/RequestForm.tsx
@@ -384,6 +384,7 @@ class RequestForm extends Component<Props> {
     } = this.props
 
     const isLoadingProducts = !orderProducts.length
+    const shouldRenderCondition = settings.displayConditionSelector ?? true
 
     return (
       <div>
@@ -448,9 +449,11 @@ class RequestForm extends Component<Props> {
                     <th className={styles.tableTh}>
                       {formatMessage({ id: messages.thReason.id })}
                     </th>
-                    <th className={styles.tableTh}>
-                      {formatMessage({ id: messages.condition.id })}
-                    </th>
+                    {shouldRenderCondition && (
+                      <th className={styles.tableTh}>
+                        {formatMessage({ id: messages.condition.id })}
+                      </th>
+                    )}
                   </tr>
                 </thead>
                 <tbody className={styles.tableTbody}>
@@ -498,11 +501,13 @@ class RequestForm extends Component<Props> {
                       >
                         {this.renderReasonsDropdown(product)}
                       </td>
-                      <td
-                        className={`${styles.tableTd} ${styles.tableTdReason}`}
-                      >
-                        {this.renderConditionDropdown(product)}
-                      </td>
+                      {shouldRenderCondition && (
+                        <td
+                          className={`${styles.tableTd} ${styles.tableTdReason}`}
+                        >
+                          {this.renderConditionDropdown(product)}
+                        </td>
+                      )}
                     </tr>
                   ))}
                 </tbody>

--- a/react/components/RequestInformation.tsx
+++ b/react/components/RequestInformation.tsx
@@ -100,13 +100,15 @@ class RequestInformation extends Component<Props> {
                           : null}
                       </div>
 
-                      <div className={`${styles.reasonStyle} ${styles.mt10}`}>
-                        <span className={styles.strongText}>
-                          {formatMessage({ id: messages.condition.id })}
-                          {': '}
-                        </span>
-                        {product.condition}{' '}
-                      </div>
+                      {product.condition && (
+                        <div className={`${styles.reasonStyle} ${styles.mt10}`}>
+                          <span className={styles.strongText}>
+                            {formatMessage({ id: messages.condition.id })}
+                            {': '}
+                          </span>
+                          {product.condition}{' '}
+                        </div>
+                      )}
                     </td>
                     <td className={`${styles.tableTd}`}>
                       {product.selectedQuantity} / {product.quantity}

--- a/react/package.json
+++ b/react/package.json
@@ -33,18 +33,18 @@
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.easypost": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.easypost@0.1.1/public/@types/vtex.easypost",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
-    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account",
+    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.react-portal": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.125.0/public/@types/vtex.store",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.159.4/public/@types/vtex.store-components",
+    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources",
+    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.86.0/public/@types/vtex.store-resources",
     "vtex.store-session": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide",
-    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
+    "vtex.telemarketing": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.11.1/public/@types/vtex.telemarketing"
   },
   "version": "2.19.6"
 }

--- a/react/store/MyReturnsPageAdd.tsx
+++ b/react/store/MyReturnsPageAdd.tsx
@@ -207,6 +207,21 @@ class MyReturnsPageAdd extends Component<Props, State> {
       })
   }
 
+  async getExtraSettings() {
+    return fetch(`${fetchPath.getExtraSettings}`, {
+      method: fetchMethod.get,
+      headers: fetchHeaders,
+    })
+      .then((response) => response.json())
+      .then((json) => {
+        if (Object.keys(json).length > 0) {
+          return Promise.resolve(json)
+        }
+
+        return Promise.resolve(null)
+      })
+  }
+
   async getProfile() {
     const { rootPath } = this.props
     const profileUrl = fetchPath.getProfile(rootPath)
@@ -503,31 +518,33 @@ class MyReturnsPageAdd extends Component<Props, State> {
 
   prepareData = () => {
     this.setState({ loading: true })
-    this.getSettings().then((settings) => {
-      if (settings !== null) {
-        this.setState({ settings })
-        this.getProfile().then((user) => {
-          this.getOrders(user.Email, settings.maxDays).then((orders) => {
-            if ('list' in orders) {
-              if (orders.list.length) {
-                orders.list.forEach((order: any) => {
-                  this.getOrder(order.orderId).then((currentOrder) => {
-                    this.prepareOrderData(currentOrder, settings, true)
+    Promise.all([this.getSettings(), this.getExtraSettings()]).then(
+      ([settings, extraSettings]) => {
+        if (settings !== null) {
+          this.setState({ ...settings, ...extraSettings })
+          this.getProfile().then((user) => {
+            this.getOrders(user.Email, settings.maxDays).then((orders) => {
+              if ('list' in orders) {
+                if (orders.list.length) {
+                  orders.list.forEach((order: any) => {
+                    this.getOrder(order.orderId).then((currentOrder) => {
+                      this.prepareOrderData(currentOrder, settings, true)
+                    })
                   })
-                })
-                setTimeout(() => {
+                  setTimeout(() => {
+                    this.setState({ loading: false })
+                  }, 1000)
+                } else {
                   this.setState({ loading: false })
-                }, 1000)
-              } else {
-                this.setState({ loading: false })
+                }
               }
-            }
+            })
           })
-        })
-      } else {
-        this.setState({ loading: false })
+        } else {
+          this.setState({ loading: false })
+        }
       }
-    })
+    )
   }
 
   componentDidMount() {
@@ -557,7 +574,10 @@ class MyReturnsPageAdd extends Component<Props, State> {
       accountHolder,
       agree,
       orderProducts,
+      settings,
     } = this.state
+
+    const shouldConsiderCondition = settings.displayConditionSelector ?? true
 
     if (!name) {
       this.setState((prevState) => ({
@@ -689,6 +709,7 @@ class MyReturnsPageAdd extends Component<Props, State> {
         errors = true
       } else if (
         parseInt(product.selectedQuantity, 10) > 0 &&
+        shouldConsiderCondition &&
         product.condition === ''
       ) {
         errors = true

--- a/react/store/MyReturnsPageAdd.tsx
+++ b/react/store/MyReturnsPageAdd.tsx
@@ -521,7 +521,7 @@ class MyReturnsPageAdd extends Component<Props, State> {
     Promise.all([this.getSettings(), this.getExtraSettings()]).then(
       ([settings, extraSettings]) => {
         if (settings !== null) {
-          this.setState({ ...settings, ...extraSettings })
+          this.setState({ settings: { ...settings, ...extraSettings } })
           this.getProfile().then((user) => {
             this.getOrders(user.Email, settings.maxDays).then((orders) => {
               if ('list' in orders) {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5082,49 +5082,49 @@ verror@1.10.0:
   version "1.6.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons#3715228fb82e81e955e6a90d11e7975e72b37b2e"
 
-"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account":
-  version "1.24.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.24.0/public/@types/vtex.my-account#f1dfdcedd359e5716d30f4765181bd52a90b37d8"
+"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account":
+  version "1.25.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account#3bc46389c0aa28f4e3e2e008fe3690f5901b1f2a"
 
 "vtex.react-portal@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal":
   version "0.4.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.react-portal@0.4.1/public/@types/vtex.react-portal#781ce4b53ba576a6365306531d8be0f1ad114769"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
-  version "8.132.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime":
+  version "8.132.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components":
-  version "3.155.9"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.155.9/public/@types/vtex.store-components#3dc767937110f31a859765e7ec21a85654151622"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.159.4/public/@types/vtex.store-components":
+  version "3.159.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.159.4/public/@types/vtex.store-components#980959f4b175469ce8e2a5d725ada92ca4ed4097"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql":
-  version "2.149.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.2/public/@types/vtex.store-graphql#f0d8a098e77875e69e5ef01453ba5e76de44e4f1"
+"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
+  version "2.152.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql#ca31214db7b9c3522ae45701732ea79022674ef8"
 
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons":
   version "0.18.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons#0ee94d549aa283ce3a13ab987c13eac4fdfd1bba"
 
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources":
-  version "0.85.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.85.0/public/@types/vtex.store-resources#c320bf775471cec37977bfb8af2cfccd4c857c63"
+"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.86.0/public/@types/vtex.store-resources":
+  version "0.86.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.86.0/public/@types/vtex.store-resources#f7342903c67ab8abe50f413b2ca4b845c93e4706"
 
 "vtex.store-session@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-session@0.3.6/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store":
-  version "2.121.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.121.1/public/@types/vtex.store#1401d6ee5e16ff8b52227213f05331bba94a5639"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.125.0/public/@types/vtex.store":
+  version "2.125.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.125.0/public/@types/vtex.store#2fcc423f7d8b1eaaf3eb5422afb52a91729a75e2"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide":
-  version "9.145.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.2/public/@types/vtex.styleguide#ca64bf8408ad3eb487b0822dd68f77565c986a56"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide":
+  version "9.146.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide#66db40ca1b78ad77ce4beedabecee320e1ef2ead"
 
-"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing":
-  version "2.10.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.10.3/public/@types/vtex.telemarketing#13f962450036d2e8d6cf79784e55d2bf418823e0"
+"vtex.telemarketing@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.11.1/public/@types/vtex.telemarketing":
+  version "2.11.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.telemarketing@2.11.1/public/@types/vtex.telemarketing#747a47bc888fce4032b384338dfc45c1f3e538ce"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
[WORKSPACE](https://sanz--vtexspain.myvtex.com/)

Leveraging the APPS client, a new settings schema was added to the manifest. Allowing customisation of the app without the need of modifying the current masterdata settings schema.

This was included to accomodate a new setting called `displayConditionSelector`, which hides the product condition select from the return request page; by default, this setting is considered `true`, making this change transparent and a minor change.

<img width="1012" alt="Screenshot" src="https://user-images.githubusercontent.com/50715158/170887483-3d42ae63-2854-4dab-91a0-9dad1ff3cda2.png">

<img width="964" alt="Screenshot" src="https://user-images.githubusercontent.com/50715158/170937300-039975bb-6b92-4fea-8317-47fcc702ad38.png">

<img width="964" alt="Screenshot" src="https://user-images.githubusercontent.com/50715158/170937311-9d832793-45ee-4239-95a6-70d690b6d8f5.png">


For minimum impact, I decided to add an extra fetch that resolves the settings and adds them to the original ones, allowing to add more in the future without breaking current implementations.

**A new endpoint and middleware was created for this.**

```js
Promise.all([this.getSettings(), this.getExtraSettings()]).then(([settings, extraSettings]) => {
  if (settings !== null) {
    this.setState({ settings: { ...settings, ...extraSettings }});
  }
})