### PR TITLE
fix: display total products value directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.19.7] - 2022-05-30
-
 ### Fixed
 
 - Fix total amount of products price by calculating directly the sum of each product value instead of relying on the totalPrice from the return request.
+
+## [2.19.7] - 2022-05-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.19.7] - 2022-05-30
 
+### Fixed
+
+- Fix total amount of products price by calculating directly the sum of each product value instead of relying on the totalPrice from the return request.
+
 ### Added
 
 - Manifest settingsSchema

--- a/react/admin/ReturnForm.tsx
+++ b/react/admin/ReturnForm.tsx
@@ -947,7 +947,6 @@ class ReturnForm extends Component<any, any> {
       giftCardValue,
       totalShippingValue,
       refundedShippingValue,
-      totalAmount,
     } = this.state
 
     const { formatMessage } = this.props.intl
@@ -984,8 +983,6 @@ class ReturnForm extends Component<any, any> {
             refundedShippingValue={refundedShippingValue}
             product={product}
             totalRefundAmount={request.refundedAmount}
-            // This is a quick (and ugly) fix for the issue where the refunded amount is not being displayed for admins.
-            productsValue={request.totalPrice || totalAmount}
           />
           <p className="mt7">
             <strong className="mr6">

--- a/react/components/ProductsTable.tsx
+++ b/react/components/ProductsTable.tsx
@@ -31,9 +31,7 @@ const ProductsTable: FunctionComponent<Props> = (props) => {
             (parseFloat(currentProduct.tax) || 0)) *
           currentProduct.quantity
 
-        console.log(currentValue, 'current value')
-
-        return (total += currentValue)
+        return total + currentValue
       }, 0)
     : 0
 

--- a/react/components/ProductsTable.tsx
+++ b/react/components/ProductsTable.tsx
@@ -10,7 +10,6 @@ import { renderIcon } from '../common/utils'
 interface Props {
   product: any
   totalRefundAmount: any
-  productsValue: any
   intl: any
   totalShippingValue: any
   refundedShippingValue: any
@@ -22,9 +21,21 @@ const ProductsTable: FunctionComponent<Props> = (props) => {
     refundedShippingValue,
     product,
     totalRefundAmount,
-    productsValue,
     intl: { formatMessage },
   } = props
+
+  const calculateTotalProductsValue = product.length
+    ? product.reduce((total, currentProduct) => {
+        const currentValue =
+          (currentProduct.unitPrice / 100 +
+            (parseFloat(currentProduct.tax) || 0)) *
+          currentProduct.quantity
+
+        console.log(currentValue, 'current value')
+
+        return (total += currentValue)
+      }, 0)
+    : 0
 
   const messages = defineMessages({
     product: { id: `returns.product` },
@@ -176,7 +187,7 @@ const ProductsTable: FunctionComponent<Props> = (props) => {
           <td className={`${styles.tableTd}`} />
           <td className={`${styles.tableTd}`} colSpan={2}>
             <strong>
-              <FormattedCurrency value={productsValue / 100} />
+              <FormattedCurrency value={calculateTotalProductsValue} />
             </strong>
           </td>
         </tr>

--- a/react/store/ReturnsDetails.tsx
+++ b/react/store/ReturnsDetails.tsx
@@ -305,7 +305,6 @@ class ReturnsDetails extends Component<any, any> {
                 totalShippingValue={totalShippingValue}
                 refundedShippingValue={request.refundedShippingValue}
                 product={product}
-                productsValue={request.totalPrice}
                 totalRefundAmount={request.refundedAmount}
               />
               <p className={`mt7 ${styles.requestInfoOrder}`}>


### PR DESCRIPTION
What is the purpose of this PR?
Fix total amount of products price by calculating directly the sum of each product value instead of relying on the totalPrice from the return request.

How to test it?
Admin
[workspace](https://total--vtexspain.myvtex.com/admin/returns/2a7d42e5-dfe8-11ec-835d-120db15413bb/details/)
Store
[workspace](https://total--vtexspain.myvtex.com/account#/my-returns/details/c7fe72a1-af9b-11ec-835d-123072a6b6a3)
