### PR TITLE
[Frontend] Replace reasons with custom reasons, when available

### DIFF
--- a/react/common/constants/returnsRequest.ts
+++ b/react/common/constants/returnsRequest.ts
@@ -1,0 +1,68 @@
+import { defaultReturnReasonsMessages } from '../../store/utils/defaultReturnReasonsMessages'
+
+export function getReasonOptions(formatMessage) {
+  return [
+    {
+      value: 'reasonAccidentalOrder',
+      label: formatMessage(defaultReturnReasonsMessages.reasonAccidentalOrder),
+    },
+    {
+      value: 'reasonBetterPrice',
+      label: formatMessage(defaultReturnReasonsMessages.reasonBetterPrice),
+    },
+    {
+      value: 'reasonPerformance',
+      label: formatMessage(defaultReturnReasonsMessages.reasonPerformance),
+    },
+    {
+      value: 'reasonIncompatible',
+      label: formatMessage(defaultReturnReasonsMessages.reasonIncompatible),
+    },
+    {
+      value: 'reasonItemDamaged',
+      label: formatMessage(defaultReturnReasonsMessages.reasonItemDamaged),
+    },
+    {
+      value: 'reasonMissedDelivery',
+      label: formatMessage(defaultReturnReasonsMessages.reasonMissedDelivery),
+    },
+    {
+      value: 'reasonMissingParts',
+      label: formatMessage(defaultReturnReasonsMessages.reasonMissingParts),
+    },
+    {
+      value: 'reasonBoxDamaged',
+      label: formatMessage(defaultReturnReasonsMessages.reasonBoxDamaged),
+    },
+    {
+      value: 'reasonDifferentProduct',
+      label: formatMessage(defaultReturnReasonsMessages.reasonDifferentProduct),
+    },
+    {
+      value: 'reasonDefective',
+      label: formatMessage(defaultReturnReasonsMessages.reasonDefective),
+    },
+    {
+      value: 'reasonArrivedInAddition',
+      label: formatMessage(
+        defaultReturnReasonsMessages.reasonArrivedInAddition
+      ),
+    },
+    {
+      value: 'reasonNoLongerNeeded',
+      label: formatMessage(defaultReturnReasonsMessages.reasonNoLongerNeeded),
+    },
+    {
+      value: 'reasonUnauthorizedPurchase',
+      label: formatMessage(
+        defaultReturnReasonsMessages.reasonUnauthorizedPurchase
+      ),
+    },
+    {
+      value: 'reasonDifferentFromWebsite',
+      label: formatMessage(
+        defaultReturnReasonsMessages.reasonDifferentFromWebsite
+      ),
+    },
+  ]
+}

--- a/react/common/constants/returnsRequest.ts
+++ b/react/common/constants/returnsRequest.ts
@@ -1,6 +1,10 @@
+import type { IntlFormatters } from 'react-intl'
+
 import { defaultReturnReasonsMessages } from '../../store/utils/defaultReturnReasonsMessages'
 
-export function getReasonOptions(formatMessage) {
+export function getReasonOptions(
+  formatMessage: IntlFormatters['formatMessage']
+) {
   return [
     {
       value: 'reasonAccidentalOrder',

--- a/react/store/createReturnRequest/components/ItemsDetails.tsx
+++ b/react/store/createReturnRequest/components/ItemsDetails.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react'
 import type { ItemCondition } from 'vtex.return-app'
 import { NumericStepper } from 'vtex.styleguide'

--- a/react/store/createReturnRequest/components/ItemsDetails.tsx
+++ b/react/store/createReturnRequest/components/ItemsDetails.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react'
 import type { ItemCondition } from 'vtex.return-app'
 import { NumericStepper } from 'vtex.styleguide'
@@ -7,15 +8,23 @@ import { CustomMessage } from './layout/CustomMessage'
 import { RenderConditionDropdown } from './RenderConditionDropdown'
 import { RenderReasonDropdown } from './RenderReasonDropdown'
 
-export const ItemsDetails = (itemToReturn: ItemToReturn) => {
+interface Props {
+  itemToReturn: ItemToReturn
+  creationDate?: string
+}
+
+export const ItemsDetails = (props: Props) => {
   const {
-    quantity,
-    quantityAvailable,
-    isExcluded,
-    orderItemIndex,
-    imageUrl,
-    name,
-  } = itemToReturn
+    itemToReturn: {
+      quantity,
+      quantityAvailable,
+      isExcluded,
+      orderItemIndex,
+      imageUrl,
+      name,
+    },
+    creationDate,
+  } = props
 
   const {
     returnRequest,
@@ -145,6 +154,7 @@ export const ItemsDetails = (itemToReturn: ItemToReturn) => {
           reason={currentItem?.returnReason?.reason ?? ''}
           otherReason={currentItem?.returnReason?.otherReason ?? ''}
           onReasonChange={handleReasonChange}
+          creationDate={creationDate}
         />
         {reasonError && reasonErrorEmptyValue ? (
           <CustomMessage

--- a/react/store/createReturnRequest/components/ItemsList.tsx
+++ b/react/store/createReturnRequest/components/ItemsList.tsx
@@ -7,9 +7,12 @@ import { CustomMessage } from './layout/CustomMessage'
 
 interface Props {
   items: ItemToReturn[]
+  creationDate?: string
 }
 
-export const ItemsList = ({ items }: Props) => {
+export const ItemsList = (props: Props) => {
+  const { items, creationDate } = props
+
   const { inputErrors } = useReturnRequest()
 
   const noItemSelected = inputErrors.some(
@@ -42,7 +45,11 @@ export const ItemsList = ({ items }: Props) => {
       </thead>
       <tbody className="v-mid">
         {items.map((item) => (
-          <ItemsDetails key={item.id} {...item} />
+          <ItemsDetails
+            key={item.id}
+            itemToReturn={item}
+            creationDate={creationDate}
+          />
         ))}
       </tbody>
       {noItemSelected ? (

--- a/react/store/createReturnRequest/components/RenderReasonDropdown.tsx
+++ b/react/store/createReturnRequest/components/RenderReasonDropdown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import type { ChangeEvent } from 'react'
 import React from 'react'
 import { useIntl } from 'react-intl'

--- a/react/store/createReturnRequest/components/RenderReasonDropdown.tsx
+++ b/react/store/createReturnRequest/components/RenderReasonDropdown.tsx
@@ -1,27 +1,34 @@
+/* eslint-disable no-console */
 import type { ChangeEvent } from 'react'
 import React from 'react'
 import { useIntl } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
 import { Dropdown, Textarea } from 'vtex.styleguide'
 
+import { getReasonOptions } from '../../../common/constants/returnsRequest'
 import { useStoreSettings } from '../../hooks/useStoreSettings'
 import { defaultReturnReasonsMessages } from '../../utils/defaultReturnReasonsMessages'
+import { generateCustomReasonOptions } from '../../utils/generateCustomReasonOptions'
 
 interface Props {
   reason: string
   otherReason: string
   onReasonChange: (reason: string, otherReason?: string) => void
   isExcluded: boolean
+  creationDate?: string
 }
 
-export const RenderReasonDropdown = ({
-  reason,
-  otherReason,
-  onReasonChange,
-  isExcluded,
-}: Props) => {
-  const { formatMessage } = useIntl()
+export const RenderReasonDropdown = (props: Props) => {
+  const { reason, otherReason, onReasonChange, isExcluded, creationDate } =
+    props
 
+  const { formatMessage } = useIntl()
   const { data: settings } = useStoreSettings()
+  const {
+    culture: { locale },
+  } = useRuntime()
+
+  const customReturnReasons = settings?.customReturnReasons
 
   const handleReasonChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
@@ -35,70 +42,17 @@ export const RenderReasonDropdown = ({
     onReasonChange('otherReason', value)
   }
 
-  const reasonOptions = [
-    {
-      value: 'reasonAccidentalOrder',
-      label: formatMessage(defaultReturnReasonsMessages.reasonAccidentalOrder),
-    },
-    {
-      value: 'reasonBetterPrice',
-      label: formatMessage(defaultReturnReasonsMessages.reasonBetterPrice),
-    },
-    {
-      value: 'reasonPerformance',
-      label: formatMessage(defaultReturnReasonsMessages.reasonPerformance),
-    },
-    {
-      value: 'reasonIncompatible',
-      label: formatMessage(defaultReturnReasonsMessages.reasonIncompatible),
-    },
-    {
-      value: 'reasonItemDamaged',
-      label: formatMessage(defaultReturnReasonsMessages.reasonItemDamaged),
-    },
-    {
-      value: 'reasonMissedDelivery',
-      label: formatMessage(defaultReturnReasonsMessages.reasonMissedDelivery),
-    },
-    {
-      value: 'reasonMissingParts',
-      label: formatMessage(defaultReturnReasonsMessages.reasonMissingParts),
-    },
-    {
-      value: 'reasonBoxDamaged',
-      label: formatMessage(defaultReturnReasonsMessages.reasonBoxDamaged),
-    },
-    {
-      value: 'reasonDifferentProduct',
-      label: formatMessage(defaultReturnReasonsMessages.reasonDifferentProduct),
-    },
-    {
-      value: 'reasonDefective',
-      label: formatMessage(defaultReturnReasonsMessages.reasonDefective),
-    },
-    {
-      value: 'reasonArrivedInAddition',
-      label: formatMessage(
-        defaultReturnReasonsMessages.reasonArrivedInAddition
-      ),
-    },
-    {
-      value: 'reasonNoLongerNeeded',
-      label: formatMessage(defaultReturnReasonsMessages.reasonNoLongerNeeded),
-    },
-    {
-      value: 'reasonUnauthorizedPurchase',
-      label: formatMessage(
-        defaultReturnReasonsMessages.reasonUnauthorizedPurchase
-      ),
-    },
-    {
-      value: 'reasonDifferentFromWebsite',
-      label: formatMessage(
-        defaultReturnReasonsMessages.reasonDifferentFromWebsite
-      ),
-    },
-  ]
+  let reasonOptions: Array<{ value: string; label: string }>
+
+  if (customReturnReasons && customReturnReasons.length > 0 && creationDate) {
+    reasonOptions = generateCustomReasonOptions(
+      customReturnReasons,
+      locale,
+      creationDate
+    )
+  } else {
+    reasonOptions = getReasonOptions(formatMessage)
+  }
 
   if (settings?.options?.enableOtherOptionSelection) {
     reasonOptions.push({

--- a/react/store/createReturnRequest/components/ReturnDetails.tsx
+++ b/react/store/createReturnRequest/components/ReturnDetails.tsx
@@ -77,7 +77,7 @@ export const ReturnDetails = (
           </div>
         </div>
       </div>
-      <ItemsList items={items} />
+      <ItemsList items={items} creationDate={creationDate} />
       <div className="flex-ns flex-wrap flex-row mt5">
         <ContactDetails />
         <AddressDetails />

--- a/react/store/utils/generateCustomReasonOptions.ts
+++ b/react/store/utils/generateCustomReasonOptions.ts
@@ -1,0 +1,38 @@
+import type { CustomReturnReason } from 'vtex.return-app'
+
+import { isWithinMaxDaysToReturn } from '../../../node/utils/dateHelpers'
+
+interface Option {
+  value: string
+  label: string
+}
+
+export function generateCustomReasonOptions(
+  customReturnReasons: CustomReturnReason[],
+  locale: string,
+  creationDate: string
+) {
+  return customReturnReasons.reduce(
+    (filteredOptions: Option[], customReason: CustomReturnReason) => {
+      if (!isWithinMaxDaysToReturn(creationDate, customReason.maxDays)) {
+        return filteredOptions
+      }
+
+      const localizedOption = customReason?.translations?.find(
+        (element) => element.locale === locale
+      )
+
+      const reason = localizedOption?.translation ?? customReason.reason
+
+      const newOption = {
+        value: reason,
+        label: reason,
+      }
+
+      filteredOptions.push(newOption)
+
+      return filteredOptions
+    },
+    []
+  )
+}


### PR DESCRIPTION
#### What problem is this solving?

If the account holder wants to have custom reasons, we will replace the default ones with those.
These custom entries can be translated, so the value/label of the selector will take the user's locale and find if the translation exists, or set the default one as it.

#### How to test it?

The following WS has 2 custom reasons, one without translation and one with a translation for each available locale.
Create a return request and see how one is always the same and the other one reacts to the user's locale.

[Workspace](http://sanz--elefantqa.myvtex.com/)