### PR TITLE
fix: encodeURI email value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix encode URI email value to avoid breaking the URL.
+
 - Fix total amount of products price by calculating directly the sum of each product value instead of relying on the totalPrice from the return request.
 
 ## [2.19.7] - 2022-05-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.19.9] - 2022-06-15
-### Fixed
-- Doesn't show message about user not having order to return while the app is still preparing the order to show.
-## [2.19.8] - 2022-06-02
-
 ### Fixed
 
 - Fix encode URI email value to avoid breaking the URL.
+
+## [2.19.9] - 2022-06-15
+
+### Fixed
+
+- Doesn't show message about user not having order to return while the app is still preparing the order to show.
+
+## [2.19.8] - 2022-06-02
+
+### Fixed
 
 - Fix total amount of products price by calculating directly the sum of each product value instead of relying on the totalPrice from the return request.
 

--- a/node/middlewares/getOrders.ts
+++ b/node/middlewares/getOrders.ts
@@ -6,7 +6,14 @@ export async function getOrders(ctx: Context, next: () => Promise<any>) {
 
   const { where } = ctx.vtex.route.params
 
-  const response = await returnAppClient.getOrders(ctx, where)
+  const whereWithEncodedClientEmail = encodeURIComponent(
+    where.slice(where.indexOf('clientEmail='), where.indexOf('&')) as string
+  )
+
+  const response = await returnAppClient.getOrders(
+    ctx,
+    whereWithEncodedClientEmail
+  )
 
   if (!response) {
     throw new Error(`Error getting orders`)

--- a/node/middlewares/getOrders.ts
+++ b/node/middlewares/getOrders.ts
@@ -6,9 +6,19 @@ export async function getOrders(ctx: Context, next: () => Promise<any>) {
 
   const { where } = ctx.vtex.route.params
 
-  const whereWithEncodedClientEmail = encodeURIComponent(
+  const clientEmail = where.slice(
+    where.indexOf('clientEmail='),
+    where.indexOf('&')
+  ) as string
+
+  const encodedClientEmail = encodeURIComponent(
     where.slice(where.indexOf('clientEmail='), where.indexOf('&')) as string
   )
+
+  const whereWithEncodedClientEmail =
+    typeof where === 'string'
+      ? where.replace(clientEmail, encodedClientEmail)
+      : where[0].replace(clientEmail, encodedClientEmail)
 
   const response = await returnAppClient.getOrders(
     ctx,


### PR DESCRIPTION
What this PR changes:
This PR is encoding the email value of the URI to avoid breaking the URL. The issue is mentioned here => https://github.com/vtex-apps/return-app/issues/121

How to test it:
[this workspace](https://v2validation--vtexspain.myvtex.com/account#/my-returns/add).

<img width="884" alt="Captura de Pantalla 2022-06-16 a la(s) 15 10 53" src="https://user-images.githubusercontent.com/96049132/174077554-a3f7d3d6-0960-45c0-9498-d13d5f5f78e7.png">
![fakeEmail](https://user-images.githubusercontent.com/96049132/174077561-17dd7e39-d595-47a3-80e9-a64b2f318862.gif)
