### PR TITLE
feat: encode email before get orders

### DIFF
--- a/node/clients/oms.ts
+++ b/node/clients/oms.ts
@@ -25,15 +25,6 @@ type InputInvoiceFields = Omit<
   'invoiceKey' | 'invoiceUrl' | 'courier' | 'trackingNumber' | 'trackingUrl'
 >
 
-interface OrderListParams {
-  clientEmail: string
-  orderBy: 'creationDate,desc'
-  f_status: 'invoiced'
-  f_creationDate: string
-  page: number
-  per_page: 10
-}
-
 export class OMSCustom extends OMS {
   constructor(ctx: IOContext, options?: InstanceOptions) {
     super(ctx, {
@@ -44,10 +35,9 @@ export class OMSCustom extends OMS {
     })
   }
 
-  public listOrdersWithParams(params?: OrderListParams) {
-    return this.http.get<OrderList>(routes.orders, {
+  public listOrdersWithParams(params?: string) {
+    return this.http.get<OrderList>(`${routes.orders}?${params}`, {
       metric: 'oms-list-order-with-params',
-      ...(params ? { params } : {}),
     })
   }
 

--- a/node/package.json
+++ b/node/package.json
@@ -23,8 +23,8 @@
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.5/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654087084/public/@types/vtex.return-app",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
+    "vtex.return-app": "https://v3validation--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654630429/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/resolvers/ordersAvailableToReturn.ts
+++ b/node/resolvers/ordersAvailableToReturn.ts
@@ -26,17 +26,12 @@ const createParams = ({
 }) => {
   const currentDate = getCurrentDate()
 
-  return {
-    clientEmail: userEmail,
-    orderBy: 'creationDate,desc' as const,
-    f_status: 'invoiced' as const,
-    f_creationDate: `creationDate:[${substractDays(
-      currentDate,
-      maxDays
-    )} TO ${currentDate}]`,
-    page,
-    per_page: 10 as const,
-  }
+  const encodedEmail = encodeURIComponent(userEmail)
+
+  return `clientEmail=${encodedEmail}&orderBy=creationDate,desc&f_status=invoiced&f_creationDate=creationDate:[${substractDays(
+    currentDate,
+    maxDays
+  )} TO ${currentDate}]&page=${page}&per_page=100`
 }
 
 export const ordersAvailableToReturn = async (

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6151,13 +6151,13 @@ verror@1.10.0:
   version "1.25.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account#3bc46389c0aa28f4e3e2e008fe3690f5901b1f2a"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.5/public/@types/vtex.render-runtime":
-  version "8.132.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.5/public/@types/vtex.render-runtime#b24290325054fa6b796ba2ff084e6d2c44ef925a"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime":
+  version "8.132.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654087084/public/@types/vtex.return-app":
+"vtex.return-app@https://v3validation--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654630429/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654087084/public/@types/vtex.return-app#b5286cb2f0572f0ffefad6c203ecde117c7c75d1"
+  resolved "https://v3validation--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654630429/public/@types/vtex.return-app#99d87c6ddaecd2bfd3b9fc5cd023a29d29eac5d5"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/package.json
+++ b/react/package.json
@@ -31,8 +31,8 @@
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.5/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654087084/public/@types/vtex.return-app",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
+    "vtex.return-app": "https://v3validation--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654630429/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5198,13 +5198,13 @@ verror@1.10.0:
   version "1.25.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account#3bc46389c0aa28f4e3e2e008fe3690f5901b1f2a"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.5/public/@types/vtex.render-runtime":
-  version "8.132.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.5/public/@types/vtex.render-runtime#b24290325054fa6b796ba2ff084e6d2c44ef925a"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime":
+  version "8.132.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654087084/public/@types/vtex.return-app":
+"vtex.return-app@https://v3validation--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654630429/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://fila--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654087084/public/@types/vtex.return-app#b5286cb2f0572f0ffefad6c203ecde117c7c75d1"
+  resolved "https://v3validation--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1654630429/public/@types/vtex.return-app#99d87c6ddaecd2bfd3b9fc5cd023a29d29eac5d5"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"


### PR DESCRIPTION
What this PR changes:
This PR is encoding the email value of the URI to avoid breaking the URL. The issue is mentioned here => https://github.com/vtex-apps/return-app/issues/121

How to test it:
[this workspace](https://v3validation--powerplanet.myvtex.com/account?__bindingAddress=www.we-demostore.com/es#/my-returns/add).