### PR TITLE
V3 return values

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -384,5 +384,15 @@
   "admin/return-app.return-request-details.table.header.unit-price": "Unit Price",
   "admin/return-app.return-request-details.table.header.tax": "Tax",
   "admin/return-app.return-request-details.table.header.total-price": "Total Price",
-  "admin/return-app.return-request-details.table.header.verification-status": "Verification Status"
+  "admin/return-app.return-request-details.table.header.verification-status": "Verification Status",
+  "admin/return-app.return-request-details.request-total.header": "Return Request Total",
+  "admin/return-app.return-request-details.request-total.item-tax": "Item (with taxes)",
+  "admin/return-app.return-request-details.request-total.shipping": "Shipping",
+  "admin/return-app.return-request-details.request-total.total": "Total",
+  "admin/return-app.return-request-details.refund-total.header-approved": "Total Refund Approved",
+  "admin/return-app.return-request-details.refund-total.header-refunded": "Total Refunded",
+  "admin/return-app.return-request-details.refund-total.item-tax": "Item (with taxes)",
+  "admin/return-app.return-request-details.refund-total.restock-fee": "Restock Fee",
+  "admin/return-app.return-request-details.refund-total.shipping": "Shipping",
+  "admin/return-app.return-request-details.refund-total.total": "Total"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -383,5 +383,15 @@
   "admin/return-app.return-request-details.table.header.unit-price": "Unit Price",
   "admin/return-app.return-request-details.table.header.tax": "Tax",
   "admin/return-app.return-request-details.table.header.total-price": "Total Price",
-  "admin/return-app.return-request-details.table.header.verification-status": "Verification Status"
+  "admin/return-app.return-request-details.table.header.verification-status": "Verification Status",
+  "admin/return-app.return-request-details.request-total.header": "Return Request Total",
+  "admin/return-app.return-request-details.request-total.item-tax": "Item (with taxes)",
+  "admin/return-app.return-request-details.request-total.shipping": "Shipping",
+  "admin/return-app.return-request-details.request-total.total": "Total",
+  "admin/return-app.return-request-details.refund-total.header-approved": "Total Refund Approved",
+  "admin/return-app.return-request-details.refund-total.header-refunded": "Total Refunded",
+  "admin/return-app.return-request-details.refund-total.item-tax": "Item (with taxes)",
+  "admin/return-app.return-request-details.refund-total.restock-fee": "Restock Fee",
+  "admin/return-app.return-request-details.refund-total.shipping": "Shipping",
+  "admin/return-app.return-request-details.refund-total.total": "Total"
 }

--- a/react/admin/ReturnDetails/ReturnDetailsContainer.tsx
+++ b/react/admin/ReturnDetails/ReturnDetailsContainer.tsx
@@ -8,6 +8,7 @@ import { useReturnDetails } from '../hooks/useReturnDetails'
 import { VerifyItemsPage } from './components/VerifyItems/VerifyItemsPage'
 import { ItemDetailsList } from './components/ItemDetails/ItemDetailsList'
 import { AdminLoader } from '../AdminLoader'
+import { ReturnValues } from './components/ReturnValues/ReturnValues'
 
 type Pages = 'return-details' | 'verify-items'
 
@@ -56,6 +57,7 @@ export const ReturnDetailsContainer = () => {
             {detailsPage !== 'return-details' ? null : (
               <>
                 <ItemDetailsList />
+                <ReturnValues />
                 <UpdateRequestStatus
                   onViewVerifyItems={() =>
                     handleViewVerifyItems('verify-items')

--- a/react/admin/ReturnDetails/components/ItemDetails/itemDetailsSchema.tsx
+++ b/react/admin/ReturnDetails/components/ItemDetails/itemDetailsSchema.tsx
@@ -132,11 +132,13 @@ export const itemDetailsSchema = (
       }: {
         rowData: ReturnRequestItem
       }) {
-        const { sellingPrice, tax } = rowData
+        const { sellingPrice, tax, quantity } = rowData
 
         return (
           <AlignItemRight>
-            <FormattedCurrency value={(sellingPrice + tax) / 100} />
+            <FormattedCurrency
+              value={((sellingPrice + tax) * quantity) / 100}
+            />
           </AlignItemRight>
         )
       },

--- a/react/admin/ReturnDetails/components/ReturnValues/ApprovedValues.tsx
+++ b/react/admin/ReturnDetails/components/ReturnValues/ApprovedValues.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { FormattedCurrency } from 'vtex.format-currency'
+
+import { useReturnDetails } from '../../../hooks/useReturnDetails'
+
+export const ApprovedValues = () => {
+  const { data } = useReturnDetails()
+  const { refundData, status } = data?.returnRequestDetails ?? {}
+
+  if (!data || !refundData) return null
+
+  const { items, invoiceValue, refundedShippingValue } = refundData
+
+  const amountItemRefund = items.reduce((total, item) => {
+    return total + item.price * item.quantity
+  }, 0)
+
+  const totalRestockFee = items.reduce((total, item) => {
+    return total + item.restockFee
+  }, 0)
+
+  return (
+    <div className="mb5">
+      {status === 'amountRefunded' ? (
+        <h3>
+          <FormattedMessage id="admin/return-app.return-request-details.refund-total.header-refunded" />
+        </h3>
+      ) : null}
+      {status === 'packageVerified' ? (
+        <h3>
+          <FormattedMessage id="admin/return-app.return-request-details.refund-total.header-approved" />
+        </h3>
+      ) : null}
+      <div className="w-100 flex flex-row-ns ba br3 b--muted-4 flex-column">
+        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
+          <div>
+            <div className="c-muted-2 f6">
+              <FormattedMessage id="admin/return-app.return-request-details.refund-total.item-tax" />
+            </div>
+            <div className="w-100 mt2">
+              <div className="f4 fw5 c-on-base">
+                <FormattedCurrency value={amountItemRefund / 100} />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns ">
+          <div className="flex flex-row">
+            <div>
+              <div className="c-muted-2 f6">
+                <FormattedMessage id="admin/return-app.return-request-details.refund-total.restock-fee" />
+              </div>
+              <div className="f4 fw5 c-danger">
+                <FormattedCurrency value={(totalRestockFee * -1) / 100} />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns ">
+          <div className="flex flex-row">
+            <div>
+              <div className="c-muted-2 f6">
+                <FormattedMessage id="admin/return-app.return-request-details.refund-total.shipping" />
+              </div>
+              <div className="f4 fw5 c-on-base">
+                <FormattedCurrency value={refundedShippingValue / 100} />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
+          <div>
+            <div className="c-muted-2 f6">
+              <FormattedMessage id="admin/return-app.return-request-details.refund-total.total" />
+            </div>
+            <div className="w-100 mt2">
+              <div className="f4 fw5 c-on-base">
+                <FormattedCurrency value={invoiceValue / 100} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/react/admin/ReturnDetails/components/ReturnValues/ApprovedValues.tsx
+++ b/react/admin/ReturnDetails/components/ReturnValues/ApprovedValues.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { FormattedCurrency } from 'vtex.format-currency'
 
 import { useReturnDetails } from '../../../hooks/useReturnDetails'
+import { TotalWrapper } from './TotalWrapper'
+import { TotalContainer } from './TotalContainer'
 
 export const ApprovedValues = () => {
   const { data } = useReturnDetails()
@@ -32,56 +33,32 @@ export const ApprovedValues = () => {
           <FormattedMessage id="admin/return-app.return-request-details.refund-total.header-approved" />
         </h3>
       ) : null}
-      <div className="w-100 flex flex-row-ns ba br3 b--muted-4 flex-column">
-        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
-          <div>
-            <div className="c-muted-2 f6">
-              <FormattedMessage id="admin/return-app.return-request-details.refund-total.item-tax" />
-            </div>
-            <div className="w-100 mt2">
-              <div className="f4 fw5 c-on-base">
-                <FormattedCurrency value={amountItemRefund / 100} />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns ">
-          <div className="flex flex-row">
-            <div>
-              <div className="c-muted-2 f6">
-                <FormattedMessage id="admin/return-app.return-request-details.refund-total.restock-fee" />
-              </div>
-              <div className="f4 fw5 c-danger">
-                <FormattedCurrency value={(totalRestockFee * -1) / 100} />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns ">
-          <div className="flex flex-row">
-            <div>
-              <div className="c-muted-2 f6">
-                <FormattedMessage id="admin/return-app.return-request-details.refund-total.shipping" />
-              </div>
-              <div className="f4 fw5 c-on-base">
-                <FormattedCurrency value={refundedShippingValue / 100} />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
-          <div>
-            <div className="c-muted-2 f6">
-              <FormattedMessage id="admin/return-app.return-request-details.refund-total.total" />
-            </div>
-            <div className="w-100 mt2">
-              <div className="f4 fw5 c-on-base">
-                <FormattedCurrency value={invoiceValue / 100} />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <TotalContainer>
+        <TotalWrapper
+          title={
+            <FormattedMessage id="admin/return-app.return-request-details.refund-total.item-tax" />
+          }
+          value={amountItemRefund}
+        />
+        <TotalWrapper
+          title={
+            <FormattedMessage id="admin/return-app.return-request-details.refund-total.restock-fee" />
+          }
+          value={totalRestockFee * -1}
+        />
+        <TotalWrapper
+          title={
+            <FormattedMessage id="admin/return-app.return-request-details.refund-total.shipping" />
+          }
+          value={refundedShippingValue}
+        />
+        <TotalWrapper
+          title={
+            <FormattedMessage id="admin/return-app.return-request-details.refund-total.total" />
+          }
+          value={invoiceValue}
+        />
+      </TotalContainer>
     </div>
   )
 }

--- a/react/admin/ReturnDetails/components/ReturnValues/RequestedValues.tsx
+++ b/react/admin/ReturnDetails/components/ReturnValues/RequestedValues.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { FormattedCurrency } from 'vtex.format-currency'
 
 import { useReturnDetails } from '../../../hooks/useReturnDetails'
+import { TotalWrapper } from './TotalWrapper'
+import { TotalContainer } from './TotalContainer'
 
 export const RequestedValues = () => {
   const { data } = useReturnDetails()
@@ -25,46 +26,26 @@ export const RequestedValues = () => {
       <h3>
         <FormattedMessage id="admin/return-app.return-request-details.request-total.header" />
       </h3>
-      <div className="w-100 flex flex-row-ns ba br3 b--muted-4 flex-column">
-        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
-          <div>
-            <div className="c-muted-2 f6">
-              <FormattedMessage id="admin/return-app.return-request-details.request-total.item-tax" />
-            </div>
-            <div className="w-100 mt2">
-              <div className="f4 fw5 c-on-base">
-                <FormattedCurrency
-                  value={(totalRefundableItems + totalRefundableTaxes) / 100}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns ">
-          <div className="flex flex-row">
-            <div>
-              <div className="c-muted-2 f6">
-                <FormattedMessage id="admin/return-app.return-request-details.request-total.shipping" />
-              </div>
-              <div className="f4 fw5 c-on-base">
-                <FormattedCurrency value={totalRefundableShipping / 100} />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
-          <div>
-            <div className="c-muted-2 f6">
-              <FormattedMessage id="admin/return-app.return-request-details.request-total.total" />
-            </div>
-            <div className="w-100 mt2">
-              <div className="f4 fw5 c-on-base">
-                <FormattedCurrency value={refundableAmount / 100} />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <TotalContainer>
+        <TotalWrapper
+          title={
+            <FormattedMessage id="admin/return-app.return-request-details.request-total.item-tax" />
+          }
+          value={totalRefundableItems + totalRefundableTaxes}
+        />
+        <TotalWrapper
+          title={
+            <FormattedMessage id="admin/return-app.return-request-details.request-total.shipping" />
+          }
+          value={totalRefundableShipping}
+        />
+        <TotalWrapper
+          title={
+            <FormattedMessage id="admin/return-app.return-request-details.request-total.total" />
+          }
+          value={refundableAmount}
+        />
+      </TotalContainer>
     </div>
   )
 }

--- a/react/admin/ReturnDetails/components/ReturnValues/RequestedValues.tsx
+++ b/react/admin/ReturnDetails/components/ReturnValues/RequestedValues.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { FormattedCurrency } from 'vtex.format-currency'
+
+import { useReturnDetails } from '../../../hooks/useReturnDetails'
+
+export const RequestedValues = () => {
+  const { data } = useReturnDetails()
+
+  if (!data) return null
+
+  const { refundableAmountTotals, refundableAmount } = data.returnRequestDetails
+
+  const totalRefundableItems =
+    refundableAmountTotals.find(({ id }) => id === 'items')?.value ?? 0
+
+  const totalRefundableTaxes =
+    refundableAmountTotals.find(({ id }) => id === 'tax')?.value ?? 0
+
+  const totalRefundableShipping =
+    refundableAmountTotals.find(({ id }) => id === 'shipping')?.value ?? 0
+
+  return (
+    <div className="mb5">
+      <h3>
+        <FormattedMessage id="admin/return-app.return-request-details.request-total.header" />
+      </h3>
+      <div className="w-100 flex flex-row-ns ba br3 b--muted-4 flex-column">
+        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
+          <div>
+            <div className="c-muted-2 f6">
+              <FormattedMessage id="admin/return-app.return-request-details.request-total.item-tax" />
+            </div>
+            <div className="w-100 mt2">
+              <div className="f4 fw5 c-on-base">
+                <FormattedCurrency
+                  value={(totalRefundableItems + totalRefundableTaxes) / 100}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns ">
+          <div className="flex flex-row">
+            <div>
+              <div className="c-muted-2 f6">
+                <FormattedMessage id="admin/return-app.return-request-details.request-total.shipping" />
+              </div>
+              <div className="f4 fw5 c-on-base">
+                <FormattedCurrency value={totalRefundableShipping / 100} />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
+          <div>
+            <div className="c-muted-2 f6">
+              <FormattedMessage id="admin/return-app.return-request-details.request-total.total" />
+            </div>
+            <div className="w-100 mt2">
+              <div className="f4 fw5 c-on-base">
+                <FormattedCurrency value={refundableAmount / 100} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/react/admin/ReturnDetails/components/ReturnValues/ReturnValues.tsx
+++ b/react/admin/ReturnDetails/components/ReturnValues/ReturnValues.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { useReturnDetails } from '../../../hooks/useReturnDetails'
+import { ApprovedValues } from './ApprovedValues'
+import { RequestedValues } from './RequestedValues'
+
+export const ReturnValues = () => {
+  const { data } = useReturnDetails()
+
+  if (!data) return null
+
+  return (
+    <section className="mv4">
+      <RequestedValues />
+      <ApprovedValues />
+    </section>
+  )
+}

--- a/react/admin/ReturnDetails/components/ReturnValues/TotalContainer.tsx
+++ b/react/admin/ReturnDetails/components/ReturnValues/TotalContainer.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react'
+import React from 'react'
+
+export const TotalContainer: FC = ({ children }) => {
+  return (
+    <div className="w-100 flex flex-row-ns ba br3 b--muted-4 flex-column">
+      {children}
+    </div>
+  )
+}

--- a/react/admin/ReturnDetails/components/ReturnValues/TotalWrapper.tsx
+++ b/react/admin/ReturnDetails/components/ReturnValues/TotalWrapper.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react'
+import React from 'react'
+import { FormattedCurrency } from 'vtex.format-currency'
+
+interface Props {
+  title: ReactElement
+  value: number
+}
+
+export const TotalWrapper = ({ title, value }: Props) => {
+  return (
+    <div className="flex flex-column pa4 b--muted-4 flex-auto bb bb-0-ns br-ns">
+      <div>
+        <div className="c-muted-2 f6">{title}</div>
+        <div className="w-100 mt2">
+          <div className="f4 fw5 c-on-base">
+            <FormattedCurrency value={value / 100} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/react/admin/graphql/returnDetailsAdminFragment.gql
+++ b/react/admin/graphql/returnDetailsAdminFragment.gql
@@ -1,6 +1,7 @@
 fragment ReturnDetailsAdminFragment on ReturnRequestResponse {
   id
   status
+  refundableAmount
   items {
     orderItemIndex
     name
@@ -20,9 +21,13 @@ fragment ReturnDetailsAdminFragment on ReturnRequestResponse {
     value
   }
   refundData {
+    refundedShippingValue
+    invoiceValue
     items {
       orderItemIndex
       quantity
+      price
+      restockFee
     }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?
This PR adds a component to show the requested and refunded amount for a return request.

#### How to test it?

The branch is linked in this [workspace](https://rmav3returnvalues--powerplanet.myvtex.com/). When seeing a return request details page, there will be a new component showing the totals that were requested. If the order is on status `amountRefunded` or `packageVerified`, there will another box with the totals there were approved or refunded. To test that scenario, one just needs to update the order status.

#### Screenshots or example usage:


<img width="1152" alt="Screen Shot 2022-06-15 at 6 19 34 PM" src="https://user-images.githubusercontent.com/38737958/173876739-03276761-877a-4f4a-93df-01650decd7c2.png">


<img width="1331" alt="Screen Shot 2022-06-15 at 6 18 51 PM" src="https://user-images.githubusercontent.com/38737958/173876765-46c24e2e-e7e8-4200-9a89-b3a36862affd.png">
