### PR TITLE
V3 add user comments to timeline

### DIFF
--- a/graphql/types/ReturnRequest.graphql
+++ b/graphql/types/ReturnRequest.graphql
@@ -171,6 +171,7 @@ type RefundStatusData {
 type RefundStatusComment {
   comment: String!
   createdAt: String!
+  role: UserRole!
   visibleForCustomer: Boolean
   submittedBy: String!
 }
@@ -218,4 +219,9 @@ enum RefundableAmountId {
   items
   shipping
   tax
+}
+
+enum UserRole {
+  adminUser
+  storeUser
 }

--- a/masterdata/returnRequest/schema.json
+++ b/masterdata/returnRequest/schema.json
@@ -210,6 +210,7 @@
                   "format": "date-time",
                   "required": true
                 },
+                "role": { "type": "string", "required": true },
                 "submittedBy": { "type": "string", "required": true },
                 "visibleForCustomer": { "type": "boolean", "required": true }
               }

--- a/masterdata/returnRequest/schema.json
+++ b/masterdata/returnRequest/schema.json
@@ -208,7 +208,8 @@
                 "createdAt": {
                   "type": "string",
                   "format": "date-time",
-                  "required": true
+                  "required": true,
+                  "enum": ["adminUser", "storeUser"]
                 },
                 "role": { "type": "string", "required": true },
                 "submittedBy": { "type": "string", "required": true },

--- a/masterdata/returnRequest/schema.json
+++ b/masterdata/returnRequest/schema.json
@@ -148,7 +148,6 @@
       }
     },
     "dateSubmitted": { "type": "string", "format": "date-time" },
-    "userComment": { "type": ["string", "null"], "maxLength": 300 },
     "refundData": {
       "type": ["object", "null"],
       "required": true,

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app",
+    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655978439/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://rmav3updatestausui--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655219193/public/@types/vtex.return-app",
+    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app",
+    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/resolvers/createReturnRequest.ts
+++ b/node/resolvers/createReturnRequest.ts
@@ -139,8 +139,9 @@ export const createReturnRequest = async (
         {
           comment: userComment,
           createdAt: requestDate,
-          submittedBy: userProfile.email,
+          submittedBy,
           visibleForCustomer: true,
+          role: 'storeUser',
         },
       ]
     : []

--- a/node/resolvers/createReturnRequest.ts
+++ b/node/resolvers/createReturnRequest.ts
@@ -134,6 +134,17 @@ export const createReturnRequest = async (
     0
   )
 
+  const userCommentData = userComment
+    ? [
+        {
+          comment: userComment,
+          createdAt: requestDate,
+          submittedBy: userProfile.email,
+          visibleForCustomer: true,
+        },
+      ]
+    : []
+
   const rmaDocument = await returnRequestClient.save({
     orderId,
     refundableAmount,
@@ -164,7 +175,7 @@ export const createReturnRequest = async (
         status: 'new',
         submittedBy,
         createdAt: requestDate,
-        comments: [],
+        comments: userCommentData,
       },
     ],
   })

--- a/node/utils/createOrUpdateStatusPayload.ts
+++ b/node/utils/createOrUpdateStatusPayload.ts
@@ -29,6 +29,7 @@ export const createOrUpdateStatusPayload = ({
         createdAt,
         submittedBy,
         visibleForCustomer: comment.visibleForCustomer,
+        role: 'adminUser',
       }
     : null
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app":
+"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app#646700804f65b9754f4597f867630163c6a32779"
+  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app#043da6358d019756d4b5370d06e0c9adcdf103e9"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://rmav3updatestausui--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655219193/public/@types/vtex.return-app":
+"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://rmav3updatestausui--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655219193/public/@types/vtex.return-app#99138860fb914a2209dede3cefc5a5756c45199e"
+  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app#646700804f65b9754f4597f867630163c6a32779"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app":
+"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655978439/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app#043da6358d019756d4b5370d06e0c9adcdf103e9"
+  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655978439/public/@types/vtex.return-app#decce4f082211831792a6558af6851b06639f039"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/admin/ReturnDetails/components/StatusTimeline/CommentList.tsx
+++ b/react/admin/ReturnDetails/components/StatusTimeline/CommentList.tsx
@@ -1,12 +1,26 @@
 import React from 'react'
-import type { RefundStatusComment } from 'vtex.return-app'
+import type { RefundStatusComment, UserRole } from 'vtex.return-app'
 import { useRuntime } from 'vtex.render-runtime'
 import { FormattedMessage } from 'react-intl'
+import { Tag } from 'vtex.styleguide'
 
 interface Props {
   comments: RefundStatusComment[]
   isLast: boolean
 }
+
+interface UserCommentTagProps {
+  userRole: UserRole
+}
+
+const UserCommentTag = ({ userRole }: UserCommentTagProps) => {
+  return userRole === 'storeUser' ? (
+    <Tag bgColor="#57bf96">Customer</Tag>
+  ) : (
+    <Tag bgColor="#3e60bd">Admin</Tag>
+  )
+}
+
 export const CommentList = ({ comments, isLast }: Props) => {
   const {
     route: { domain },
@@ -19,14 +33,19 @@ export const CommentList = ({ comments, isLast }: Props) => {
       {comments?.map((comment) => (
         <li key={comment.createdAt}>
           {contextDomain === 'admin' ? (
-            <FormattedMessage
-              id="admin/return-app.return-request-details.status-timeline.comment"
-              values={{
-                ts: new Date(comment.createdAt),
-                comment: comment.comment,
-                submittedBy: comment.submittedBy,
-              }}
-            />
+            <div className="pa2">
+              <span className="mr3">
+                <FormattedMessage
+                  id="admin/return-app.return-request-details.status-timeline.comment"
+                  values={{
+                    ts: new Date(comment.createdAt),
+                    comment: comment.comment,
+                    submittedBy: comment.submittedBy,
+                  }}
+                />
+              </span>
+              <UserCommentTag userRole={comment.role} />
+            </div>
           ) : null}
           {contextDomain === 'store' ? (
             <FormattedMessage

--- a/react/admin/graphql/returnDetailsAdminFragment.gql
+++ b/react/admin/graphql/returnDetailsAdminFragment.gql
@@ -65,6 +65,7 @@ fragment ReturnDetailsAdminFragment on ReturnRequestResponse {
       createdAt
       visibleForCustomer
       submittedBy
+      role
     }
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app",
+    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655978439/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app",
+    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "https://rmav3updatestausui--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655219193/public/@types/vtex.return-app",
+    "vtex.return-app": "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://rmav3updatestausui--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655219193/public/@types/vtex.return-app":
+"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://rmav3updatestausui--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655219193/public/@types/vtex.return-app#99138860fb914a2209dede3cefc5a5756c45199e"
+  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app#646700804f65b9754f4597f867630163c6a32779"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app":
+"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655904814/public/@types/vtex.return-app#646700804f65b9754f4597f867630163c6a32779"
+  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app#043da6358d019756d4b5370d06e0c9adcdf103e9"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5202,9 +5202,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app":
+"vtex.return-app@https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655978439/public/@types/vtex.return-app":
   version "3.0.0-beta.6"
-  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655911513/public/@types/vtex.return-app#043da6358d019756d4b5370d06e0c9adcdf103e9"
+  resolved "https://returnappusercomments--powerplanet.myvtex.com/_v/private/typings/linked/v1/vtex.return-app@3.0.0-beta.6+build1655978439/public/@types/vtex.return-app#decce4f082211831792a6558af6851b06639f039"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.152.0/public/@types/vtex.store-graphql":
   version "2.152.0"


### PR DESCRIPTION
#### What problem is this solving?

Add the user comments to the return request timeline when the request is created

#### How to test it?

[Workspace](https://returnappusercomments--powerplanet.myvtex.com/admin)

#### Screenshots or example usage:

<img width="755" alt="Screenshot 2022-06-21 at 10 24 38" src="https://user-images.githubusercontent.com/102956976/174756101-90d4767f-614f-4a2d-8e30-7fb024b10bfa.png">
