### PR TITLE
Hotfix: request list redirect

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -455,7 +455,7 @@
   "return-app.return-request-list.table.status.processing": "Processing",
   "return-app.return-request-list.table.status.pickedup-from-client": "Picked up from client",
   "return-app.return-request-list.table.status.pending-verification": "Pending verification",
-  "return-app.return-request-list.table.status.package-verified": "Package Verified",
+  "return-app.return-request-list.table.status.package-verified": "Package verified",
   "return-app.return-request-list.table.status.refunded": "Refunded",
   "return-app.return-request-list.table.status.denied": "Denied",
   "return-app.return-request-list.table.status.approved": "Approved",
@@ -463,5 +463,6 @@
   "admin/return-app.return-request-details.table.status-history.header.created-at": "Created At",
   "admin/return-app.return-request-details.table.status-history.header.status": "Status",
   "admin/return-app.return-request-details.table.status-history.header.submitted-by": "Submitted By",
-  "admin/return-app.return-request-details.status-history.title": "Status History"
+  "admin/return-app.return-request-details.status-history.title": "Status History",
+  "admin/return-app.return-request-list.table-data.requestId.tooltip": "Tooltip with an explanation of how the customer can access the data"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -453,7 +453,7 @@
   "return-app.return-request-list.table.status.processing": "Processing",
   "return-app.return-request-list.table.status.pickedup-from-client": "Picked up from client",
   "return-app.return-request-list.table.status.pending-verification": "Pending verification",
-  "return-app.return-request-list.table.status.package-verified": "Package Verified",
+  "return-app.return-request-list.table.status.package-verified": "Package verified",
   "return-app.return-request-list.table.status.refunded": "Refunded",
   "return-app.return-request-list.table.status.denied": "Denied",
   "return-app.return-request-list.table.status.approved": "Approved",
@@ -461,5 +461,6 @@
   "admin/return-app.return-request-details.table.status-history.header.created-at": "Created At",
   "admin/return-app.return-request-details.table.status-history.header.status": "Status",
   "admin/return-app.return-request-details.table.status-history.header.submitted-by": "Submitted By",
-  "admin/return-app.return-request-details.status-history.title": "Status History"
+  "admin/return-app.return-request-details.status-history.title": "Status History",
+  "admin/return-app.return-request-list.table-data.requestId.tooltip": "Customers can see their Request ID inside the request detail"
 }

--- a/react/common/components/returnList/ListTable.tsx
+++ b/react/common/components/returnList/ListTable.tsx
@@ -73,7 +73,6 @@ const ListTable = () => {
       />
       <Table
         fullWidth
-        fixFirstColumn
         loading={loading}
         items={list}
         emptyStateLabel={
@@ -96,7 +95,7 @@ const ListTable = () => {
           totalItems: paging?.total,
         }}
       />
-      {paging && list?.length ? (
+      {paging && list?.length && !loading ? (
         <JumpToPage
           handleJumpToPage={handleJumpToPage}
           currentPage={paging.currentPage}

--- a/react/common/components/returnList/ListTableFilter.tsx
+++ b/react/common/components/returnList/ListTableFilter.tsx
@@ -8,6 +8,7 @@ import type {
   Status,
 } from 'vtex.return-app'
 import type { ApolloQueryResult } from 'apollo-client'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { StatusActionMenu } from './StatusActionMenu'
 
@@ -47,6 +48,7 @@ const initialFilters = {
 const ListTableFilter = (props: Props) => {
   const { refetch, loading, isDisabled } = props
 
+  const { route } = useRuntime()
   const [isFiltering, setIsFiltering] = useState(false)
   const [filters, setFilters] = useState(initialFilters)
 
@@ -110,21 +112,23 @@ const ListTableFilter = (props: Props) => {
   return (
     <form onSubmit={handleSubmitFilters}>
       <div className="flex items-center">
-        <div className="mr2">
-          <FormattedMessage id="return-app.return-request-list.table-data.requestId">
-            {(formattedMessage) => (
-              <Input
-                placeholder={formattedMessage}
-                size="small"
-                value={filters.id}
-                onChange={(e: FormEvent<HTMLInputElement>) =>
-                  handleOnChange('id', e.currentTarget.value)
-                }
-                disabled={isDisabled && !isFiltering}
-              />
-            )}
-          </FormattedMessage>
-        </div>
+        {route.domain === 'admin' ? (
+          <div className="mr2">
+            <FormattedMessage id="return-app.return-request-list.table-data.requestId">
+              {(formattedMessage) => (
+                <Input
+                  placeholder={formattedMessage}
+                  size="small"
+                  value={filters.id}
+                  onChange={(e: FormEvent<HTMLInputElement>) =>
+                    handleOnChange('id', e.currentTarget.value)
+                  }
+                  disabled={isDisabled && !isFiltering}
+                />
+              )}
+            </FormattedMessage>
+          </div>
+        ) : null}
         <div className="mh2">
           <FormattedMessage id="return-app.return-request-list.table-data.sequenceNumber">
             {(formattedMessage) => (
@@ -200,8 +204,7 @@ const ListTableFilter = (props: Props) => {
           <Button
             size="small"
             type="submit"
-            disabled={!hasSelectedFilters}
-            isLoading={loading}
+            disabled={!hasSelectedFilters || loading}
           >
             <FormattedMessage id="return-app.return-request-list.table-filters.apply-filters" />
           </Button>
@@ -210,9 +213,8 @@ const ListTableFilter = (props: Props) => {
           <Button
             size="small"
             onClick={handleResetFilters}
-            disabled={!isFiltering}
+            disabled={!isFiltering || loading}
             variation="danger"
-            isLoading={loading}
           >
             <FormattedMessage id="return-app.return-request-list.table-filters.clear-filters" />
           </Button>

--- a/react/common/components/returnList/ListTableSchema.tsx
+++ b/react/common/components/returnList/ListTableSchema.tsx
@@ -6,9 +6,11 @@ import {
   IconFailure,
   IconVisibilityOn,
   IconCheck,
+  IconInfo,
   IconSuccess,
   IconExternalLinkMini,
   ButtonPlain,
+  Tooltip,
 } from 'vtex.styleguide'
 import type { Status } from 'vtex.return-app'
 
@@ -23,36 +25,69 @@ const status = {
 } as const
 
 const ReturnListSchema = () => {
-  const { navigate } = useRuntime()
+  const { navigate, route } = useRuntime()
+
+  const adminDomain = route.domain === 'admin'
 
   const navigateToRequest = (id: string) => {
+    const page = adminDomain
+      ? `/admin/app/returns/${id}/details/`
+      : `#/my-returns/details/${id}`
+
     navigate({
-      to: `/admin/app/returns/${id}/details`,
+      to: page,
     })
   }
 
   return {
     properties: {
-      id: {
-        title: (
-          <FormattedMessage id="return-app.return-request-list.table-data.requestId" />
-        ),
-        minWidth: 310,
-        cellRenderer({ cellData }) {
-          return (
-            <ButtonPlain
-              size="small"
-              onClick={() => navigateToRequest(cellData)}
-            >
-              {cellData}
-            </ButtonPlain>
-          )
+      ...(adminDomain && {
+        id: {
+          title: (
+            <FormattedMessage id="return-app.return-request-list.table-data.requestId" />
+          ),
+          headerRenderer({ title }) {
+            return (
+              <div className="flex items-center">
+                {title}
+                <Tooltip
+                  label={
+                    <FormattedMessage id="admin/return-app.return-request-list.table-data.requestId.tooltip" />
+                  }
+                >
+                  <span className="yellow pointer ml3 flex">
+                    <IconInfo />
+                  </span>
+                </Tooltip>
+              </div>
+            )
+          },
+          minWidth: 310,
+          cellRenderer({ cellData }) {
+            return (
+              <ButtonPlain
+                size="small"
+                onClick={() => navigateToRequest(cellData)}
+              >
+                {cellData}
+              </ButtonPlain>
+            )
+          },
         },
-      },
+      }),
       sequenceNumber: {
         title: (
           <FormattedMessage id="return-app.return-request-list.table-data.sequenceNumber" />
         ),
+        ...(!adminDomain && {
+          cellRenderer({ cellData, rowData }) {
+            return (
+              <ButtonPlain onClick={() => navigateToRequest(rowData.id)}>
+                {cellData}
+              </ButtonPlain>
+            )
+          },
+        }),
       },
       orderId: {
         title: (

--- a/react/common/components/returnList/StatusActionMenu.tsx
+++ b/react/common/components/returnList/StatusActionMenu.tsx
@@ -18,19 +18,19 @@ const keyedStatusMessages = defineMessages({
   processing: {
     id: 'return-app.return-request-list.table.status.processing',
   },
-  picked: {
+  pickedUpFromClient: {
     id: 'return-app.return-request-list.table.status.pickedup-from-client',
   },
   pendingVerification: {
     id: 'return-app.return-request-list.table.status.pending-verification',
   },
-  verified: {
+  packageVerified: {
     id: 'return-app.return-request-list.table.status.package-verified',
   },
   denied: {
     id: 'return-app.return-request-list.table.status.denied',
   },
-  refunded: {
+  amountRefunded: {
     id: 'return-app.return-request-list.table.status.refunded',
   },
 })

--- a/react/hooks/useReturnRequestList.ts
+++ b/react/hooks/useReturnRequestList.ts
@@ -17,6 +17,7 @@ export const useReturnRequestList = () => {
       page: 1,
     },
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'no-cache',
   })
 
   return { returnRequestData: { data, loading, error, refetch } }

--- a/react/store/ReturnRequest/StoreReturnList.tsx
+++ b/react/store/ReturnRequest/StoreReturnList.tsx
@@ -14,7 +14,7 @@ export const StoreReturnList = () => {
     <Button
       variation="primary"
       size="small"
-      isLoading={loading}
+      disabled={loading}
       href="#/my-returns/add"
     >
       <FormattedMessage id="store/return-app.return-request-list.page-header.cta" />

--- a/react/store/createReturnRequest/components/ConfirmAndSubmit.tsx
+++ b/react/store/createReturnRequest/components/ConfirmAndSubmit.tsx
@@ -71,6 +71,8 @@ export const ConfirmAndSubmit = ({ onPageChange, items }: Props) => {
     setConfirmationStatus('idle')
     navigate({
       to: `#/my-returns`,
+      replace: true,
+      fetchPage: false,
     })
   }
 

--- a/react/store/createReturnRequest/components/ConfirmAndSubmit.tsx
+++ b/react/store/createReturnRequest/components/ConfirmAndSubmit.tsx
@@ -72,7 +72,6 @@ export const ConfirmAndSubmit = ({ onPageChange, items }: Props) => {
     navigate({
       to: `#/my-returns`,
       replace: true,
-      fetchPage: false,
     })
   }
 


### PR DESCRIPTION
When successfully creating a return request, in My account, the alert CTA to navigate back to the request return list won't trigger a re-render, and the new request will be missing until refreshing the page.

[WORKSPACE](https://sanzstore--powerplanet.myvtex.com)

![screenshot](https://user-images.githubusercontent.com/50715158/177134680-25759ca1-dc37-40c8-a322-bef227c1b106.png)
