### PR TITLE
fix: keyboard input jump to page

### DIFF
--- a/react/common/components/returnList/JumpToPage.tsx
+++ b/react/common/components/returnList/JumpToPage.tsx
@@ -13,14 +13,24 @@ const JumpToPage = (props: Props) => {
   const { handleJumpToPage, currentPage, maxPage } = props
 
   const [desiredPage, setDesiredPage] = useState(currentPage)
+  const [canSubmit, setEnableSubmit] = useState(true)
 
   useEffect(() => {
-    setDesiredPage(currentPage)
-  }, [currentPage])
+    if (desiredPage > maxPage || desiredPage <= 0) {
+      setEnableSubmit(false)
+
+      return
+    }
+
+    setEnableSubmit(true)
+  }, [desiredPage, maxPage])
 
   const handleOnChange = (page: number) => {
-    if (page > maxPage || page <= 0) return
     setDesiredPage(page)
+  }
+
+  const handleSubmit = () => {
+    handleJumpToPage(desiredPage)
   }
 
   return (
@@ -51,8 +61,8 @@ const JumpToPage = (props: Props) => {
           <Button
             variation="secondary"
             size="small"
-            onClick={() => handleJumpToPage(desiredPage)}
-            disabled={!desiredPage}
+            onClick={handleSubmit}
+            disabled={!desiredPage || !canSubmit}
           >
             <FormattedMessage id="return-app.return-request-list.table-jumpToPage.cta" />
           </Button>


### PR DESCRIPTION
[WORKSPACE](https://sanzstore--powerplanet.myvtex.com/admin/returns/requests)

Minor adjustment on how the input works in the `JUMP TO PAGE` component.

Previously it constrained the input to be between min and max pages, but the constrain was applied on the target event value, which made it not UX friendly.

Now any value is accepted and the constrain will be handled in an effect that disables the submit button.

> How to test it: input any value below 1 or above the max page, the GO button will be disabled.