### PR TITLE
Fix/v3/locale create endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add locale into context to allow item names to be translated when creating a new request via API.
+
 ## [3.0.0] - 2022-07-26
 
 ## [2.19.12] - 2022-06-27
+### Fixed
 - Encode user email when getting orders to be returned.
 
 ## [2.19.11] - 2022-06-17

--- a/node/clients/catalogGQL.ts
+++ b/node/clients/catalogGQL.ts
@@ -25,6 +25,8 @@ export class CatalogGQL extends AppGraphQLClient {
       headers: {
         ...opts?.headers,
         cookie: `VtexIdclientAutCookie=${ctx.authToken}`,
+        'x-vtex-locale': ctx.locale ?? '',
+        'X-Vtex-Tenant': ctx.account,
       },
     })
   }

--- a/node/middlewares/createReturn.ts
+++ b/node/middlewares/createReturn.ts
@@ -1,3 +1,4 @@
+import { UserInputError } from '@vtex/api'
 import { json } from 'co-body'
 
 import { createReturnRequestService } from '../services/createReturnRequestService'
@@ -6,6 +7,14 @@ export async function createReturn(ctx: Context) {
   const { req } = ctx
 
   const body = await json(req)
+
+  const { locale } = body
+
+  if (!locale) {
+    throw new UserInputError('Locale is required.')
+  }
+
+  ctx.vtex.locale = locale
 
   ctx.body = await createReturnRequestService(ctx, body)
   ctx.status = 201

--- a/node/utils/translateItems.ts
+++ b/node/utils/translateItems.ts
@@ -10,11 +10,15 @@ export const translateItemName = async (
   originalName: string,
   catalogClient: CatalogGQL
 ) => {
-  const skuName = await catalogClient.getSKUTranslation(id)
+  try {
+    const skuName = await catalogClient.getSKUTranslation(id)
+    const isLocalized = skuName && skuName !== originalName
 
-  const isLocalized = skuName && skuName !== originalName
-
-  return isLocalized ? skuName : null
+    return isLocalized ? skuName : null
+  } catch (error) {
+    error.message = 'Error translating item name'
+    throw error
+  }
 }
 
 export function handleTranlateItems(


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes an issue preventing the creation of a RMA via endpoint due to an error on the request translating the items name.

#### How to test it?

To this ENDPOINT https://filafixcreaterma--powerplanet.myvtex.com/_v/return-request, make a POST request to create a new return request.

#### Describe alternatives you've considered, if any.

I considered passing the `locale` directly to `translateItemName` function and then apply it to the method getting the translation. However, the function is called in different places and always in a deeper level then the context where the `locale` was available. Adding it to `context.vtex.locale` in the higher level of the middleware handling the POST to create a request, we ensure locale is available in the context. 
