### PR TITLE
refactor: format date numeric

### DIFF
--- a/react/common/components/returnList/ListTableSchema.tsx
+++ b/react/common/components/returnList/ListTableSchema.tsx
@@ -83,8 +83,8 @@ const ReturnListSchema = () => {
           return (
             <FormattedDate
               value={cellData}
-              day="numeric"
-              month="long"
+              day="2-digit"
+              month="2-digit"
               year="numeric"
             />
           )

--- a/react/store/createReturnRequest/components/ReturnDetails.tsx
+++ b/react/store/createReturnRequest/components/ReturnDetails.tsx
@@ -86,8 +86,8 @@ export const ReturnDetails = (
                 <div className="f4 fw5 c-on-base">
                   <FormattedDate
                     value={creationDate}
-                    day="numeric"
-                    month="long"
+                    day="2-digit"
+                    month="2-digit"
                     year="numeric"
                   />
                 </div>


### PR DESCRIPTION
#### What problem is this solving?

Change format date  to numeric on `My returns` and `Return Details` components to avoid differences with different countries.

#### How to test it?

[Workspace](https://date--powerplanet.myvtex.com/account?__bindingAddress=www.we-demostore.com/es#/my-returns)

#### Screenshots or example usage:

Before:
![Captura de Pantalla 2022-08-10 a la(s) 10 28 21](https://user-images.githubusercontent.com/96049132/183855743-20593f64-d0b3-4e47-9a3c-f1f4120bf123.png)
![Captura de Pantalla 2022-08-10 a la(s) 10 32 45](https://user-images.githubusercontent.com/96049132/183855752-4e0d9beb-18a9-45d4-b7bf-f0c0dcb4c3b8.png)

After:
![Captura de Pantalla 2022-08-10 a la(s) 10 34 00](https://user-images.githubusercontent.com/96049132/183856075-62a5ca4c-28db-45ce-b620-e30ab7f0c22c.png)
![Captura de Pantalla 2022-08-10 a la(s) 10 34 16](https://user-images.githubusercontent.com/96049132/183856076-1b21c2b4-1d6b-411d-91dd-613cf95e2d2a.png)

