### PR TITLE
Responsive store returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Mobile inconsistencies in My-account pages
+
 ### Added
 - Bulgarian, Dutch, French, Italian, Portuguese, Romanian, Spanish and Thai translations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- My account mobile inconsistencies
+- Dynamic messages declared statically
 
 ## [3.4.0] - 2022-08-17
 ### Fixed
 - Prevent order list and order details paegs to show negative numbers for available items.
 - Avoid having a minus sign when restock fee is 0.
+- English translations.
 
 ### Changed
 
@@ -20,11 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Bulgarian, Dutch, French, Italian, Portuguese, Romanian, Spanish and Thai translations.
 
-### Fixed
 
-- English translations.
-- My account mobile inconsistencies
-- Dynamic messages declared statically
 
 ## [3.3.0] - 2022-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
-- Mobile inconsistencies in My-account pages
-
 ### Added
 - Bulgarian, Dutch, French, Italian, Portuguese, Romanian, Spanish and Thai translations.
 
 ### Fixed
 - English translations.
+- My account mobile inconsistencies
+- Dynamic messages declared statically
 
 ## [3.3.0] - 2022-08-11
 

--- a/react/admin/ReturnDetails/components/VerifyItems/verifyItemsTableSchema.tsx
+++ b/react/admin/ReturnDetails/components/VerifyItems/verifyItemsTableSchema.tsx
@@ -174,7 +174,7 @@ export const verifyItemsTableSchema = (
             currencyCode={cultureInfoData.currencyCode}
             locale={cultureInfoData.locale}
             onChange={handleChange}
-            disabled={selectedQuantity === 0}
+            readOnly={selectedQuantity === 0}
           />
         )
       },

--- a/react/common/components/ReturnDetails/ItemDetails/ItemDetailsList.tsx
+++ b/react/common/components/ReturnDetails/ItemDetails/ItemDetailsList.tsx
@@ -7,6 +7,7 @@ import type {
   Maybe,
 } from 'vtex.return-app'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 import { useIntl } from 'react-intl'
 
 import { useReturnDetails } from '../../../hooks/useReturnDetails'
@@ -85,6 +86,9 @@ export const ItemDetailsList = () => {
   const handles = useCssHandles(CSS_HANDLES)
   const { formatMessage } = useIntl()
   const { data } = useReturnDetails()
+  const {
+    hints: { phone },
+  } = useRuntime()
 
   if (!data) return null
 
@@ -105,11 +109,12 @@ export const ItemDetailsList = () => {
         fullWidth
         dynamicRowHeight
         items={items}
-        schema={itemDetailsSchema(
+        schema={itemDetailsSchema({
           itemsVerificationStatus,
           currencyCode,
-          formatMessage
-        )}
+          formatMessage,
+          isSmallScreen: phone,
+        })}
       />
     </section>
   )

--- a/react/common/components/ReturnDetails/ItemDetails/itemDetailsSchema.tsx
+++ b/react/common/components/ReturnDetails/ItemDetails/itemDetailsSchema.tsx
@@ -12,12 +12,20 @@ import { defaultReturnConditionsMessages } from '../../../utils/defaultReturnCon
 
 const StrongChunk = (chunks: ReactElement) => <b>{chunks}</b>
 
-export const itemDetailsSchema = (
-  itemVerificationStatus: Map<number, ItemStatusInterface>,
-  currency: string,
+interface Props {
+  itemsVerificationStatus: Map<number, ItemStatusInterface>
+  currencyCode: string
   formatMessage: IntlFormatters['formatMessage']
-) => ({
-  properties: {
+  isSmallScreen: boolean
+}
+
+export const itemDetailsSchema = ({
+  itemsVerificationStatus,
+  currencyCode,
+  formatMessage,
+  isSmallScreen,
+}: Props) => {
+  const properties = {
     imageUrl: {
       title: (
         <FormattedMessage id="return-app.return-request-details.table.header.product" />
@@ -121,7 +129,7 @@ export const itemDetailsSchema = (
             <FormattedNumber
               value={cellData / 100}
               style="currency"
-              currency={currency}
+              currency={currencyCode}
             />
           </AlignItemRight>
         )
@@ -143,7 +151,7 @@ export const itemDetailsSchema = (
             <FormattedNumber
               value={cellData / 100}
               style="currency"
-              currency={currency}
+              currency={currencyCode}
             />
           </AlignItemRight>
         )
@@ -167,7 +175,7 @@ export const itemDetailsSchema = (
             <FormattedNumber
               value={((sellingPrice + tax) * quantity) / 100}
               style="currency"
-              currency={currency}
+              currency={currencyCode}
             />
           </AlignItemRight>
         )
@@ -177,18 +185,31 @@ export const itemDetailsSchema = (
       title: (
         <FormattedMessage id="return-app.return-request-details.table.header.verification-status" />
       ),
+      minWidth: 150,
       cellRenderer: function VerificationStatus({
         rowData,
       }: {
         rowData: ReturnRequestItem
       }) {
         const { orderItemIndex } = rowData
-        const itemStatus = itemVerificationStatus.get(orderItemIndex)
+        const itemStatus = itemsVerificationStatus.get(orderItemIndex)
 
         if (!itemStatus) return null
 
         return <ItemVerificationStatus {...itemStatus} />
       },
     },
-  },
-})
+  }
+
+  const mobileOrder = {
+    imageUrl: null,
+    name: null,
+    verificationStatus: null,
+  }
+
+  return {
+    properties: isSmallScreen
+      ? Object.assign(mobileOrder, properties)
+      : properties,
+  }
+}

--- a/react/common/components/ReturnDetails/RequestCancellation.tsx
+++ b/react/common/components/ReturnDetails/RequestCancellation.tsx
@@ -36,6 +36,7 @@ const RequestCancellation = () => {
   const { data } = useReturnDetails()
   const {
     route: { domain },
+    hints: { phone },
   } = useRuntime()
 
   const { submitting, handleStatusUpdate } = useUpdateRequestStatus()
@@ -83,14 +84,16 @@ const RequestCancellation = () => {
 
   return (
     <>
-      <Button
-        variation="danger"
-        size="small"
-        onClick={onOpen}
-        disabled={isDisabled}
-      >
-        <FormattedMessage id="return-app.return-request-details.cancellation.cta" />
-      </Button>
+      <div className={phone ? 'mt4' : ''}>
+        <Button
+          variation="danger"
+          size="small"
+          onClick={onOpen}
+          disabled={isDisabled}
+        >
+          <FormattedMessage id="return-app.return-request-details.cancellation.cta" />
+        </Button>
+      </div>
 
       <Modal
         size="small"

--- a/react/common/components/ReturnDetails/RequestCancellation.tsx
+++ b/react/common/components/ReturnDetails/RequestCancellation.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import type { FormEvent, ReactElement } from 'react'
 import { utils, Button, EXPERIMENTAL_Modal as Modal } from 'vtex.styleguide'
 import { useRuntime } from 'vtex.render-runtime'
-import { defineMessages, FormattedMessage } from 'react-intl'
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl'
 
 import { useReturnDetails } from '../../hooks/useReturnDetails'
 import { useUpdateRequestStatus } from '../../../admin/hooks/useUpdateRequestStatus'
@@ -38,6 +38,8 @@ const RequestCancellation = () => {
     route: { domain },
     hints: { phone },
   } = useRuntime()
+
+  const { formatMessage } = useIntl()
 
   const { submitting, handleStatusUpdate } = useUpdateRequestStatus()
 
@@ -126,12 +128,9 @@ const RequestCancellation = () => {
         }
       >
         <div>
-          <FormattedMessage
-            id={`${messages[messageKey].id}`}
-            values={{
-              p: ParagraphChunk,
-            }}
-          />
+          {formatMessage(messages[messageKey], {
+            p: ParagraphChunk,
+          })}
         </div>
       </Modal>
     </>

--- a/react/common/components/ReturnDetails/StatusHistory.tsx
+++ b/react/common/components/ReturnDetails/StatusHistory.tsx
@@ -22,12 +22,13 @@ const statusHistorySchema = (
       title: (
         <FormattedMessage id="return-app.return-request-details.table.status-history.header.created-at" />
       ),
+      minWidth: 120,
       cellRenderer: function CreatedAt({ cellData }) {
         return (
           <FormattedDate
             value={cellData}
-            day="numeric"
-            month="long"
+            day="2-digit"
+            month="2-digit"
             year="numeric"
             hour="numeric"
             minute="numeric"
@@ -40,6 +41,7 @@ const statusHistorySchema = (
       title: (
         <FormattedMessage id="return-app.return-request-details.table.status-history.header.status" />
       ),
+      minWidth: 150,
       cellRenderer: function Status({ cellData }) {
         return formatMessage(statusMessageIdAdmin[cellData])
       },

--- a/react/common/components/returnList/ListTable.tsx
+++ b/react/common/components/returnList/ListTable.tsx
@@ -18,7 +18,7 @@ const ListTable = () => {
 
   const {
     route: { domain },
-    hints: { mobile },
+    hints: { mobile, phone },
   } = useRuntime()
 
   const isAdmin = domain === 'admin'
@@ -110,7 +110,7 @@ const ListTable = () => {
           totalItems: paging?.total,
         }}
       />
-      {paging && list?.length && !loading ? (
+      {!phone && paging && list?.length && !loading ? (
         <JumpToPage
           handleJumpToPage={handleJumpToPage}
           currentPage={paging.currentPage}

--- a/react/common/components/returnList/ListTable.tsx
+++ b/react/common/components/returnList/ListTable.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { Table, EmptyState } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 import ReturnListSchema from './ListTableSchema'
 import JumpToPage from './JumpToPage'
@@ -14,6 +15,13 @@ const ListTable = () => {
   const {
     returnRequestData: { data, loading, error, refetch },
   } = useReturnRequestList()
+
+  const {
+    route: { domain },
+    hints: { mobile },
+  } = useRuntime()
+
+  const isAdmin = domain === 'admin'
 
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -71,11 +79,13 @@ const ListTable = () => {
 
   return (
     <div className={handles.listTableContainer}>
-      <ListTableFilter
-        refetch={refetch}
-        loading={loading}
-        isDisabled={!list?.length}
-      />
+      {mobile && !isAdmin ? null : (
+        <ListTableFilter
+          refetch={refetch}
+          loading={loading}
+          isDisabled={!list?.length}
+        />
+      )}
       <Table
         fullWidth
         loading={loading}

--- a/react/common/components/returnList/ListTableFilter.tsx
+++ b/react/common/components/returnList/ListTableFilter.tsx
@@ -128,7 +128,7 @@ const ListTableFilter = (props: Props) => {
                   onChange={(e: FormEvent<HTMLInputElement>) =>
                     handleOnChange('id', e.currentTarget.value)
                   }
-                  disabled={isDisabled && !isFiltering}
+                  readOnly={isDisabled && !isFiltering}
                 />
               )}
             </FormattedMessage>
@@ -144,7 +144,7 @@ const ListTableFilter = (props: Props) => {
                 onChange={(e: FormEvent<HTMLInputElement>) =>
                   handleOnChange('sequenceNumber', e.currentTarget.value)
                 }
-                disabled={isDisabled && !isFiltering}
+                readOnly={isDisabled && !isFiltering}
               />
             )}
           </FormattedMessage>
@@ -159,7 +159,7 @@ const ListTableFilter = (props: Props) => {
                 onChange={(e: FormEvent<HTMLInputElement>) =>
                   handleOnChange('orderId', e.currentTarget.value)
                 }
-                disabled={isDisabled && !isFiltering}
+                readOnly={isDisabled && !isFiltering}
               />
             )}
           </FormattedMessage>

--- a/react/common/components/returnList/ListTableSchema.tsx
+++ b/react/common/components/returnList/ListTableSchema.tsx
@@ -6,12 +6,16 @@ import { IconInfo, ButtonPlain, Tooltip } from 'vtex.styleguide'
 import { renderStatus } from '../RenderStatus'
 
 const ReturnListSchema = () => {
-  const { navigate, route } = useRuntime()
+  const {
+    navigate,
+    route: { domain },
+    hints: { phone },
+  } = useRuntime()
 
-  const adminDomain = route.domain === 'admin'
+  const isAdmin = domain === 'admin'
 
   const navigateToRequest = (id: string) => {
-    const page = adminDomain
+    const page = isAdmin
       ? `/admin/app/returns/${id}/details/`
       : `#/my-returns/details/${id}`
 
@@ -22,7 +26,7 @@ const ReturnListSchema = () => {
 
   return {
     properties: {
-      ...(adminDomain && {
+      ...(isAdmin && {
         id: {
           title: (
             <FormattedMessage id="return-app.return-request-list.table-data.requestId" />
@@ -60,7 +64,7 @@ const ReturnListSchema = () => {
         title: (
           <FormattedMessage id="return-app.return-request-list.table-data.sequenceNumber" />
         ),
-        ...(!adminDomain && {
+        ...(!isAdmin && {
           cellRenderer({ cellData, rowData }) {
             return (
               <ButtonPlain onClick={() => navigateToRequest(rowData.id)}>

--- a/react/common/components/returnList/ListTableSchema.tsx
+++ b/react/common/components/returnList/ListTableSchema.tsx
@@ -9,7 +9,6 @@ const ReturnListSchema = () => {
   const {
     navigate,
     route: { domain },
-    hints: { phone },
   } = useRuntime()
 
   const isAdmin = domain === 'admin'
@@ -64,6 +63,7 @@ const ReturnListSchema = () => {
         title: (
           <FormattedMessage id="return-app.return-request-list.table-data.sequenceNumber" />
         ),
+        minWidth: 100,
         ...(!isAdmin && {
           cellRenderer({ cellData, rowData }) {
             return (
@@ -78,6 +78,7 @@ const ReturnListSchema = () => {
         title: (
           <FormattedMessage id="return-app.return-request-list.table-data.orderId" />
         ),
+        minWidth: 160,
       },
       createdIn: {
         title: (
@@ -93,11 +94,13 @@ const ReturnListSchema = () => {
             />
           )
         },
+        minWidth: 110,
       },
       status: {
         title: (
           <FormattedMessage id="return-app.return-request-list.table-data.status" />
         ),
+        minWidth: 250,
         cellRenderer({ cellData }) {
           return renderStatus(cellData)
         },

--- a/react/store/ReturnRequest/StoreReturnDetails.tsx
+++ b/react/store/ReturnRequest/StoreReturnDetails.tsx
@@ -29,43 +29,44 @@ const StoreReturnDetails = () => {
   const handles = useCssHandles(CSS_HANDLES)
 
   return (
-    <PageBlock>
-      <PageHeader
-        title={
-          <FormattedMessage id="store/return-app.return-request-details.page-header.title" />
-        }
-        linkLabel={
-          <FormattedMessage id="store/return-app.return-request-details.page-header.link-label" />
-        }
-        onLinkClick={() => {
-          navigate({
-            to: '#/my-returns',
-          })
-        }}
-      >
-        <AlertProvider>
-          <UpdateRequestStatusProvider>
-            <RequestCancellation />
-          </UpdateRequestStatusProvider>
-        </AlertProvider>
-      </PageHeader>
-
-      <StoreReturnDetailsLoader data={{ loading, error }}>
-        <CurrentRequestStatus />
-        <OrderLink />
-        <ItemDetailsList />
-        <ReturnValues />
-        <div
-          className={`${handles.contactPickupContainer} flex-ns flex-wrap flex-row`}
+    <div className="returnDetailContainer">
+      <PageBlock>
+        <PageHeader
+          title={
+            <FormattedMessage id="store/return-app.return-request-details.page-header.title" />
+          }
+          linkLabel={
+            <FormattedMessage id="store/return-app.return-request-details.page-header.link-label" />
+          }
+          onLinkClick={() => {
+            navigate({
+              to: '#/my-returns',
+            })
+          }}
         >
-          <ContactDetails />
-          <PickupAddress />
-        </div>
-        <RefundMethodDetail />
-        <StatusTimeline />
-        <StatusHistory />
-      </StoreReturnDetailsLoader>
-    </PageBlock>
+          <AlertProvider>
+            <UpdateRequestStatusProvider>
+              <RequestCancellation />
+            </UpdateRequestStatusProvider>
+          </AlertProvider>
+        </PageHeader>
+        <StoreReturnDetailsLoader data={{ loading, error }}>
+          <CurrentRequestStatus />
+          <OrderLink />
+          <ItemDetailsList />
+          <ReturnValues />
+          <div
+            className={`${handles.contactPickupContainer} flex-ns flex-wrap flex-row`}
+          >
+            <ContactDetails />
+            <PickupAddress />
+          </div>
+          <RefundMethodDetail />
+          <StatusTimeline />
+          <StatusHistory />
+        </StoreReturnDetailsLoader>
+      </PageBlock>
+    </div>
   )
 }
 

--- a/react/store/ReturnRequest/StoreReturnDetails.tsx
+++ b/react/store/ReturnRequest/StoreReturnDetails.tsx
@@ -29,7 +29,7 @@ const StoreReturnDetails = () => {
   const handles = useCssHandles(CSS_HANDLES)
 
   return (
-    <div className="returnDetailContainer">
+    <div className="return-detail__container">
       <PageBlock>
         <PageHeader
           title={

--- a/react/store/ReturnRequest/StoreReturnList.tsx
+++ b/react/store/ReturnRequest/StoreReturnList.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Button, PageBlock } from 'vtex.styleguide'
+import { Button } from 'vtex.styleguide'
 import { ContentWrapper } from 'vtex.my-account-commons'
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
 
 import ListTable from '../../common/components/returnList/ListTable'
 import { useReturnRequestList } from '../../hooks/useReturnRequestList'
@@ -16,19 +17,25 @@ const messages = defineMessages({
 })
 
 export const StoreReturnList = () => {
-  const { returnRequestData } = useReturnRequestList()
+  const {
+    hints: { phone },
+  } = useRuntime()
+
   const { formatMessage } = useIntl()
+  const { returnRequestData } = useReturnRequestList()
   const { loading } = returnRequestData
 
   const headerContent = (
-    <Button
-      variation="primary"
-      size="small"
-      disabled={loading}
-      href="#/my-returns/add"
-    >
-      <FormattedMessage id="store/return-app.return-request-list.page-header.cta" />
-    </Button>
+    <div className={`${phone ? 'mt4' : 'mt2'}`}>
+      <Button
+        variation="primary"
+        size="small"
+        disabled={loading}
+        href="#/my-returns/add"
+      >
+        <FormattedMessage id="store/return-app.return-request-list.page-header.cta" />
+      </Button>
+    </div>
   )
 
   return (
@@ -41,11 +48,7 @@ export const StoreReturnList = () => {
       }}
       headerContent={headerContent}
     >
-      {() => (
-        <PageBlock variation="full">
-          <ListTable />
-        </PageBlock>
-      )}
+      {() => <ListTable />}
     </ContentWrapper>
   )
 }

--- a/react/store/createReturnRequest/CreateReturnRequest.tsx
+++ b/react/store/createReturnRequest/CreateReturnRequest.tsx
@@ -117,31 +117,30 @@ export const CreateReturnRequest = (props: RouteProps) => {
   }
 
   return (
-    <PageBlock className="ph0 mh0 pa0 pa0-ns">
-      <PageHeader
-        className="ph0 mh0 nl5"
-        {...createPageHeaderProps(page, navigate)}
-      />
-      <OrderDetailsLoader data={{ loading, error }}>
-        {page === 'form-details' && data ? (
-          <>
-            <ReturnDetails
-              {...props}
-              onPageChange={handlePageChange}
-              items={items}
-              creationDate={data.orderToReturnSummary.creationDate}
-              canRefundCard={
-                data?.orderToReturnSummary.paymentData.canRefundCard
-              }
-              shippingData={data.orderToReturnSummary.shippingData}
-            />
-          </>
-        ) : null}
-        {page === 'submit-form' ? (
-          <ConfirmAndSubmit onPageChange={handlePageChange} items={items} />
-        ) : null}
-      </OrderDetailsLoader>
-    </PageBlock>
+    <div className="createReturnRequestContainer">
+      <PageBlock>
+        <PageHeader {...createPageHeaderProps(page, navigate)} />
+        <OrderDetailsLoader data={{ loading, error }}>
+          {page === 'form-details' && data ? (
+            <>
+              <ReturnDetails
+                {...props}
+                onPageChange={handlePageChange}
+                items={items}
+                creationDate={data.orderToReturnSummary.creationDate}
+                canRefundCard={
+                  data?.orderToReturnSummary.paymentData.canRefundCard
+                }
+                shippingData={data.orderToReturnSummary.shippingData}
+              />
+            </>
+          ) : null}
+          {page === 'submit-form' ? (
+            <ConfirmAndSubmit onPageChange={handlePageChange} items={items} />
+          ) : null}
+        </OrderDetailsLoader>
+      </PageBlock>
+    </div>
   )
 }
 

--- a/react/store/createReturnRequest/CreateReturnRequest.tsx
+++ b/react/store/createReturnRequest/CreateReturnRequest.tsx
@@ -117,7 +117,7 @@ export const CreateReturnRequest = (props: RouteProps) => {
   }
 
   return (
-    <div className="createReturnRequestContainer">
+    <div className="create-return-request__container">
       <PageBlock>
         <PageHeader {...createPageHeaderProps(page, navigate)} />
         <OrderDetailsLoader data={{ loading, error }}>

--- a/react/store/createReturnRequest/components/AddressDetails.tsx
+++ b/react/store/createReturnRequest/components/AddressDetails.tsx
@@ -168,7 +168,7 @@ export const AddressDetails = ({ shippingData }: Props) => {
           placeholder={formatMessage(messages.addressInput)}
           onChange={handleInputChange}
           value={pickupReturnData.address}
-          disabled={isPickupPoint}
+          readOnly={isPickupPoint}
         />
         {addressError && !pickupReturnData.address ? (
           <CustomMessage
@@ -186,7 +186,7 @@ export const AddressDetails = ({ shippingData }: Props) => {
           placeholder={formatMessage(messages.cityInput)}
           onChange={handleInputChange}
           value={pickupReturnData.city}
-          disabled={isPickupPoint}
+          readOnly={isPickupPoint}
         />
         {addressError && !pickupReturnData.city ? (
           <CustomMessage
@@ -204,7 +204,7 @@ export const AddressDetails = ({ shippingData }: Props) => {
           placeholder={formatMessage(messages.stateInput)}
           onChange={handleInputChange}
           value={pickupReturnData.state}
-          disabled={isPickupPoint}
+          readOnly={isPickupPoint}
         />
         {addressError && !pickupReturnData.state ? (
           <CustomMessage
@@ -222,7 +222,7 @@ export const AddressDetails = ({ shippingData }: Props) => {
           placeholder={formatMessage(messages.zipInput)}
           onChange={handleInputChange}
           value={pickupReturnData.zipCode}
-          disabled={isPickupPoint}
+          readOnly={isPickupPoint}
         />
         {addressError && !pickupReturnData.zipCode ? (
           <CustomMessage
@@ -240,7 +240,7 @@ export const AddressDetails = ({ shippingData }: Props) => {
           placeholder={formatMessage(messages.countryInput)}
           onChange={handleInputChange}
           value={pickupReturnData.country}
-          disabled={isPickupPoint}
+          readOnly={isPickupPoint}
         />
         {addressError && !pickupReturnData.country ? (
           <CustomMessage

--- a/react/store/createReturnRequest/components/ConfirmAndSubmit.tsx
+++ b/react/store/createReturnRequest/components/ConfirmAndSubmit.tsx
@@ -47,6 +47,7 @@ export const ConfirmAndSubmit = ({ onPageChange, items }: Props) => {
   const {
     navigate,
     culture: { locale },
+    hints: { phone },
   } = useRuntime()
 
   const { data: storeSettings } = useStoreSettings()
@@ -117,7 +118,11 @@ export const ConfirmAndSubmit = ({ onPageChange, items }: Props) => {
                 className={`${handles.confirmationActionsContainer} flex flex-wrap`}
               >
                 <section
-                  className={`${handles.contactAddressWrapper} w-100 flex flex-wrap justify-between`}
+                  className={`${
+                    handles.contactAddressWrapper
+                  } w-100 flex flex-wrap justify-between ${
+                    phone ? 'flex-column' : ''
+                  }`}
                 >
                   <ConfirmContactDetails
                     contactDetails={returnRequestValidated.customerProfileData}
@@ -127,7 +132,11 @@ export const ConfirmAndSubmit = ({ onPageChange, items }: Props) => {
                   />
                 </section>
                 <section
-                  className={`${handles.paymentCommentWrapper} w-100 flex mt5 justify-between`}
+                  className={`${
+                    handles.paymentCommentWrapper
+                  } w-100 flex mt5 justify-between ${
+                    phone ? 'flex-column' : ''
+                  }`}
                 >
                   <ConfirmPaymentMethods
                     refundPaymentData={returnRequestValidated.refundPaymentData}
@@ -169,26 +178,40 @@ export const ConfirmAndSubmit = ({ onPageChange, items }: Props) => {
               </Alert>
             )}
             {confirmationStatus !== 'idle' ? null : (
-              <>
-                <div className={`${handles.backButtonWrapper} mr3`}>
+              <div
+                className={`flex ${
+                  phone ? 'w-100 flex-column' : 'justify-center'
+                }`}
+              >
+                <div
+                  className={`${handles.backButtonWrapper} ${
+                    phone ? 'mb5' : 'mr3'
+                  }`}
+                >
                   <Button
-                    size="small"
+                    block={phone}
+                    size={phone ? 'normal' : 'small'}
                     variation="secondary"
                     onClick={() => handlePageChange()}
                   >
                     <FormattedMessage id="store/return-app.confirm-and-submit.button.back" />
                   </Button>
                 </div>
-                <div className={`${handles.submitButtonWrapper} ml3`}>
+                <div
+                  className={`${handles.submitButtonWrapper} ${
+                    phone ? '' : 'mr3'
+                  }`}
+                >
                   <Button
-                    size="small"
+                    block={phone}
+                    size={phone ? 'normal' : 'small'}
                     onClick={handleCreateReturnRequest}
                     isLoading={creatingReturnRequest}
                   >
                     <FormattedMessage id="store/return-app.confirm-and-submit.button.submit" />
                   </Button>
                 </div>
-              </>
+              </div>
             )}
           </section>
         </>

--- a/react/store/createReturnRequest/components/ConfirmComment.tsx
+++ b/react/store/createReturnRequest/components/ConfirmComment.tsx
@@ -1,15 +1,20 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
 
 interface Props {
   userComment?: string | null
 }
 
 export const ConfirmComment = ({ userComment }: Props) => {
+  const {
+    hints: { phone },
+  } = useRuntime()
+
   return (
     <>
       {!userComment ? null : (
-        <div className="w-40">
+        <div className={`${phone ? 'w-100' : 'w-40'}`}>
           <h2 className="mt0 mb6 pr6">
             <FormattedMessage id="store/return-app.confirm-and-submit.user-comment.title" />
           </h2>

--- a/react/store/createReturnRequest/components/ConfirmContactDetails.tsx
+++ b/react/store/createReturnRequest/components/ConfirmContactDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import type { CustomerProfileDataInput } from 'vtex.return-app'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 interface Props {
   contactDetails: CustomerProfileDataInput
@@ -16,8 +17,16 @@ const CSS_HANDLES = [
 export const ConfirmContactDetails = ({ contactDetails }: Props) => {
   const handles = useCssHandles(CSS_HANDLES)
 
+  const {
+    hints: { phone },
+  } = useRuntime()
+
   return (
-    <div className={`${handles.confirmContactContainer} w-40`}>
+    <div
+      className={`${handles.confirmContactContainer} ${
+        phone ? 'w-100' : 'w-40'
+      }`}
+    >
       <h2 className={`${handles.confirmContactTitle} mt0 mb6`}>
         <FormattedMessage id="store/return-app.confirm-and-submit.contact-details.title" />
       </h2>

--- a/react/store/createReturnRequest/components/ConfirmPaymentMethods.tsx
+++ b/react/store/createReturnRequest/components/ConfirmPaymentMethods.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 import type { RefundPaymentDataInput } from 'vtex.return-app'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { defaultPaymentMethodsMessages } from '../../utils/defaultPaymentMethodsMessages'
 
@@ -23,9 +24,16 @@ const CSS_HANDLES = [
 export const ConfirmPaymentMethods = ({ refundPaymentData }: Props) => {
   const { formatMessage } = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
+  const {
+    hints: { phone },
+  } = useRuntime()
 
   return (
-    <div className={`${handles.confirmPaymentContainer} w-40`}>
+    <div
+      className={`${handles.confirmPaymentContainer} ${
+        phone ? 'w-100' : 'w-40'
+      }`}
+    >
       <h2 className={`${handles.confirmPaymentTitle} mt0 mb6`}>
         <FormattedMessage id="store/return-app.confirm-and-submit.refund-method.title" />
       </h2>

--- a/react/store/createReturnRequest/components/ConfirmPickupAddressDetails.tsx
+++ b/react/store/createReturnRequest/components/ConfirmPickupAddressDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import type { PickupReturnDataInput } from 'vtex.return-app'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 interface Props {
   pickupReturnData: PickupReturnDataInput
@@ -15,9 +16,16 @@ const CSS_HANDLES = [
 
 export const ConfirmPickupAddressDetails = ({ pickupReturnData }: Props) => {
   const handles = useCssHandles(CSS_HANDLES)
+  const {
+    hints: { phone },
+  } = useRuntime()
 
   return (
-    <div className={`${handles.confirmPickupContainer} w-40`}>
+    <div
+      className={`${handles.confirmPickupContainer} ${
+        phone ? 'w-100' : 'w-40'
+      }`}
+    >
       <h2 className={`${handles.confirmPickupTitle} mt0 mb6`}>
         <FormattedMessage id="store/return-app.confirm-and-submit.pickup-address.title" />
       </h2>

--- a/react/store/createReturnRequest/components/ContactDetails.tsx
+++ b/react/store/createReturnRequest/components/ContactDetails.tsx
@@ -80,7 +80,7 @@ export const ContactDetails = () => {
       </div>
       <div className={`${handles.contactEmailInputWrapper} mb4`}>
         <Input
-          disabled
+          readOnly
           name="email"
           placeholder={formatMessage(messages.emailInput)}
           onChange={handleInputChange}

--- a/react/store/createReturnRequest/components/ItemsDetails.tsx
+++ b/react/store/createReturnRequest/components/ItemsDetails.tsx
@@ -3,6 +3,7 @@ import type { ItemCondition } from 'vtex.return-app'
 import { NumericStepper } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 import { FormattedMessage } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { useReturnRequest } from '../../hooks/useReturnRequest'
 import { CustomMessage } from './layout/CustomMessage'
@@ -38,6 +39,10 @@ export const ItemsDetails = (props: Props) => {
     },
     creationDate,
   } = props
+
+  const {
+    hints: { phone },
+  } = useRuntime()
 
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -139,35 +144,51 @@ export const ItemsDetails = (props: Props) => {
 
   return (
     <tr className={`${handles.detailsRowContainer}`}>
-      <td className={`${handles.detailsTdWrapper}`}>
-        <section className={`${handles.productSectionWrapper} ml3`}>
-          <p className={`${handles.productText} t-body fw5`}>
-            {localizedName ?? name}
-          </p>
-          <div className={`${handles.productImageWrapper} flex`}>
+      <td className={`${handles.detailsTdWrapper} pa4`}>
+        <section
+          className={`${handles.productSectionWrapper} flex ${
+            phone ? 'w5' : ''
+          }`}
+        >
+          <div
+            className={`${handles.productImageWrapper} flex`}
+            style={{ flexBasis: '50%' }}
+          >
             <img
               className={`${handles.productImage}`}
               src={imageUrl}
               alt="Product"
             />
-            {isExcluded ? (
-              <CustomMessage
-                status="warning"
-                message={
-                  <FormattedMessage id="store/return-app.return-item-details.excluded-items.warning" />
-                }
-              />
-            ) : null}
           </div>
+          <p
+            className={`${handles.productText} t-body fw5 ml3`}
+            style={{ flexBasis: '100%' }}
+          >
+            {localizedName ?? name}
+          </p>
+          {isExcluded ? (
+            <CustomMessage
+              status="warning"
+              message={
+                <FormattedMessage id="store/return-app.return-item-details.excluded-items.warning" />
+              }
+            />
+          ) : null}
         </section>
       </td>
-      <td className={`${handles.detailsTdWrapper}`}>
-        <p className={`${handles.itemsDetailText} tc`}>{quantity}</p>
-      </td>
-      <td className={`${handles.detailsTdWrapper}`}>
-        <p className={`${handles.itemsDetailText} tc`}>{availableToReturn}</p>
-      </td>
-      <td className={`${handles.detailsTdWrapper}`}>
+      {phone ? null : (
+        <>
+          <td className={`${handles.detailsTdWrapper} pa4`}>
+            <p className={`${handles.itemsDetailText} tc`}>{quantity}</p>
+          </td>
+          <td className={`${handles.detailsTdWrapper} pa4`}>
+            <p className={`${handles.itemsDetailText} tc`}>
+              {availableToReturn}
+            </p>
+          </td>
+        </>
+      )}
+      <td className={`${handles.detailsTdWrapper} pa4`}>
         <NumericStepper
           size="small"
           maxValue={availableToReturn}
@@ -175,7 +196,7 @@ export const ItemsDetails = (props: Props) => {
           onChange={(e: { value: number }) => handleQuantityChange(e.value)}
         />
       </td>
-      <td className={`${handles.detailsTdWrapper}`}>
+      <td className={`${handles.detailsTdWrapper} pa4`}>
         <RenderReasonDropdown
           isExcluded={isExcluded}
           reason={currentItem?.returnReason?.reason ?? ''}
@@ -193,7 +214,7 @@ export const ItemsDetails = (props: Props) => {
         ) : null}
       </td>
       {!enableSelectItemCondition ? null : (
-        <td className={`${handles.detailsTdWrapper}`}>
+        <td className={`${handles.detailsTdWrapper} pa4`}>
           <RenderConditionDropdown
             isExcluded={isExcluded}
             condition={currentItem?.condition ?? ''}
@@ -208,6 +229,18 @@ export const ItemsDetails = (props: Props) => {
             />
           ) : null}
         </td>
+      )}
+      {!phone ? null : (
+        <>
+          <td className={`${handles.detailsTdWrapper} pa4`}>
+            <p className={`${handles.itemsDetailText} tc`}>{quantity}</p>
+          </td>
+          <td className={`${handles.detailsTdWrapper} pa4`}>
+            <p className={`${handles.itemsDetailText} tc`}>
+              {availableToReturn}
+            </p>
+          </td>
+        </>
       )}
     </tr>
   )

--- a/react/store/createReturnRequest/components/ItemsDetails.tsx
+++ b/react/store/createReturnRequest/components/ItemsDetails.tsx
@@ -142,6 +142,17 @@ export const ItemsDetails = (props: Props) => {
 
   const availableToReturn = isExcluded ? 0 : quantityAvailable
 
+  const ItemQuantityDataCell = (
+    <>
+      <td className={`${handles.detailsTdWrapper} pa4`}>
+        <p className={`${handles.itemsDetailText} tc`}>{quantity}</p>
+      </td>
+      <td className={`${handles.detailsTdWrapper} pa4`}>
+        <p className={`${handles.itemsDetailText} tc`}>{availableToReturn}</p>
+      </td>
+    </>
+  )
+
   return (
     <tr className={`${handles.detailsRowContainer}`}>
       <td className={`${handles.detailsTdWrapper} pa4`}>
@@ -176,18 +187,7 @@ export const ItemsDetails = (props: Props) => {
           ) : null}
         </section>
       </td>
-      {phone ? null : (
-        <>
-          <td className={`${handles.detailsTdWrapper} pa4`}>
-            <p className={`${handles.itemsDetailText} tc`}>{quantity}</p>
-          </td>
-          <td className={`${handles.detailsTdWrapper} pa4`}>
-            <p className={`${handles.itemsDetailText} tc`}>
-              {availableToReturn}
-            </p>
-          </td>
-        </>
-      )}
+      {phone ? null : ItemQuantityDataCell}
       <td className={`${handles.detailsTdWrapper} pa4`}>
         <NumericStepper
           size="small"
@@ -230,18 +230,7 @@ export const ItemsDetails = (props: Props) => {
           ) : null}
         </td>
       )}
-      {!phone ? null : (
-        <>
-          <td className={`${handles.detailsTdWrapper} pa4`}>
-            <p className={`${handles.itemsDetailText} tc`}>{quantity}</p>
-          </td>
-          <td className={`${handles.detailsTdWrapper} pa4`}>
-            <p className={`${handles.itemsDetailText} tc`}>
-              {availableToReturn}
-            </p>
-          </td>
-        </>
-      )}
+      {!phone ? null : ItemQuantityDataCell}
     </tr>
   )
 }

--- a/react/store/createReturnRequest/components/ItemsList.tsx
+++ b/react/store/createReturnRequest/components/ItemsList.tsx
@@ -106,7 +106,9 @@ export const ItemsList = (props: Props) => {
         className={`${handles.itemsListContainer} w-100 ph4 truncate overflow-x-hidden c-muted-2 f6`}
       >
         <tr className="w-100 truncate overflow-x-hidden">
-          {phone ? mobileOrder.map(TableHeader) : desktopOrder.map(TableHeader)}
+          {phone
+            ? mobileOrder.map((header) => TableHeader(header))
+            : desktopOrder.map((header) => TableHeader(header))}
         </tr>
       </thead>
       <tbody className="v-mid return-itemsList-body">

--- a/react/store/createReturnRequest/components/ItemsList.tsx
+++ b/react/store/createReturnRequest/components/ItemsList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { FormattedMessage } from 'react-intl'
+import type { IntlFormatters } from 'react-intl'
+import { FormattedMessage, defineMessages, useIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { useRuntime } from 'vtex.render-runtime'
 
@@ -33,7 +34,31 @@ const mobileOrder = [
   'available-to-return',
 ]
 
-const TableHeader = (addCondition: boolean) => {
+export const messages = defineMessages({
+  product: {
+    id: 'store/return-app.return-order-details.table-header.product',
+  },
+  quantity: {
+    id: 'store/return-app.return-order-details.table-header.quantity',
+  },
+  'available-to-return': {
+    id: 'store/return-app.return-order-details.table-header.available-to-return',
+  },
+  'quantity-to-return': {
+    id: 'store/return-app.return-order-details.table-header.quantity-to-return',
+  },
+  reason: {
+    id: 'store/return-app.return-order-details.table-header.reason',
+  },
+  condition: {
+    id: 'store/return-app.return-order-details.table-header.condition',
+  },
+})
+
+const TableHeaderRenderer = (
+  formatMessage: IntlFormatters['formatMessage'],
+  addCondition: boolean
+) => {
   return function Header(value: string) {
     if (!addCondition && value === 'condition') {
       return
@@ -41,9 +66,7 @@ const TableHeader = (addCondition: boolean) => {
 
     return (
       <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s">
-        <FormattedMessage
-          id={`store/return-app.return-order-details.table-header.${value}`}
-        />
+        {formatMessage(messages[value])}
       </th>
     )
   }
@@ -60,6 +83,8 @@ export const ItemsList = (props: Props) => {
     hints: { phone },
   } = useRuntime()
 
+  const { formatMessage } = useIntl()
+
   const handles = useCssHandles(CSS_HANDLES)
   const { inputErrors } = useReturnRequest()
 
@@ -67,7 +92,10 @@ export const ItemsList = (props: Props) => {
     (error) => error === 'no-item-selected'
   )
 
-  const RenderHeader = TableHeader(enableSelectItemCondition)
+  const TableHeader = TableHeaderRenderer(
+    formatMessage,
+    Boolean(enableSelectItemCondition)
+  )
 
   return (
     <table
@@ -78,9 +106,7 @@ export const ItemsList = (props: Props) => {
         className={`${handles.itemsListContainer} w-100 ph4 truncate overflow-x-hidden c-muted-2 f6`}
       >
         <tr className="w-100 truncate overflow-x-hidden">
-          {phone
-            ? mobileOrder.map(RenderHeader)
-            : desktopOrder.map(RenderHeader)}
+          {phone ? mobileOrder.map(TableHeader) : desktopOrder.map(TableHeader)}
         </tr>
       </thead>
       <tbody className="v-mid return-itemsList-body">

--- a/react/store/createReturnRequest/components/ItemsList.tsx
+++ b/react/store/createReturnRequest/components/ItemsList.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { useReturnRequest } from '../../hooks/useReturnRequest'
 import { useStoreSettings } from '../../hooks/useStoreSettings'
@@ -14,12 +15,50 @@ interface Props {
 
 const CSS_HANDLES = ['itemsListContainer', 'itemsListTheadWrapper'] as const
 
+const desktopOrder = [
+  'product',
+  'quantity',
+  'available-to-return',
+  'quantity-to-return',
+  'reason',
+  'condition',
+]
+
+const mobileOrder = [
+  'product',
+  'quantity-to-return',
+  'reason',
+  'condition',
+  'quantity',
+  'available-to-return',
+]
+
+const TableHeader = (addCondition: boolean) => {
+  return function Header(value: string) {
+    if (!addCondition && value === 'condition') {
+      return
+    }
+
+    return (
+      <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s">
+        <FormattedMessage
+          id={`store/return-app.return-order-details.table-header.${value}`}
+        />
+      </th>
+    )
+  }
+}
+
 export const ItemsList = (props: Props) => {
   const { items, creationDate } = props
 
   const { data: storeSettings } = useStoreSettings()
   const { options } = storeSettings ?? {}
   const { enableSelectItemCondition } = options ?? {}
+
+  const {
+    hints: { phone },
+  } = useRuntime()
 
   const handles = useCssHandles(CSS_HANDLES)
   const { inputErrors } = useReturnRequest()
@@ -28,35 +67,23 @@ export const ItemsList = (props: Props) => {
     (error) => error === 'no-item-selected'
   )
 
+  const RenderHeader = TableHeader(enableSelectItemCondition)
+
   return (
-    <table className={`${handles.itemsListContainer} w-100`}>
+    <table
+      className={`${handles.itemsListContainer} w-100`}
+      style={{ borderCollapse: 'collapse' }}
+    >
       <thead
         className={`${handles.itemsListContainer} w-100 ph4 truncate overflow-x-hidden c-muted-2 f6`}
       >
         <tr className="w-100 truncate overflow-x-hidden">
-          <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s">
-            <FormattedMessage id="store/return-app.return-order-details.table-header.product" />
-          </th>
-          <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
-            <FormattedMessage id="store/return-app.return-order-details.table-header.quantity" />
-          </th>
-          <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
-            <FormattedMessage id="store/return-app.return-order-details.table-header.available-to-return" />
-          </th>
-          <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
-            <FormattedMessage id="store/return-app.return-order-details.table-header.quantity-to-return" />
-          </th>
-          <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
-            <FormattedMessage id="store/return-app.return-order-details.table-header.reason" />
-          </th>
-          {!enableSelectItemCondition ? null : (
-            <th className="v-mid pv0 tl bb b--muted-4 normal bg-base bt ph3 z1 pv3-s tc">
-              <FormattedMessage id="store/return-app.return-order-details.table-header.condition" />
-            </th>
-          )}
+          {phone
+            ? mobileOrder.map(RenderHeader)
+            : desktopOrder.map(RenderHeader)}
         </tr>
       </thead>
-      <tbody className="v-mid">
+      <tbody className="v-mid return-itemsList-body">
         {items.map((item) => (
           <ItemsDetails
             key={item.id}

--- a/react/store/createReturnRequest/components/PickupPointSelector.tsx
+++ b/react/store/createReturnRequest/components/PickupPointSelector.tsx
@@ -124,7 +124,6 @@ export const PickupPointSelector = ({ geoCoordinates }: Props) => {
                 ) : undefined
               }
               placeholder={placehoder}
-              size="small"
               options={pickupPointsDropdownOptions}
               value={pickupReturnData.addressId}
               onChange={handlePickupPointSelected}

--- a/react/store/createReturnRequest/components/ReturnDetails.tsx
+++ b/react/store/createReturnRequest/components/ReturnDetails.tsx
@@ -4,6 +4,7 @@ import type { RouteComponentProps } from 'react-router'
 import type { ShippingData } from 'vtex.return-app'
 import { useCssHandles } from 'vtex.css-handles'
 import { Divider, Button } from 'vtex.styleguide'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { ContactDetails } from './ContactDetails'
 import { AddressDetails } from './AddressDetails'
@@ -46,6 +47,10 @@ export const ReturnDetails = (
   const {
     actions: { areFieldsValid },
   } = useReturnRequest()
+
+  const {
+    hints: { phone },
+  } = useRuntime()
 
   const handleFieldsValidation = () => {
     if (areFieldsValid()) {
@@ -99,8 +104,10 @@ export const ReturnDetails = (
       <div className="t-body lh-copy c-muted-1 mb3 ml3 w-two-thirds-ns w-100">
         <FormattedMessage id="store/return-app.return-order-details.page-header.subtitle" />
       </div>
-      <ItemsList items={items} creationDate={creationDate} />
-      <div className="mv8">
+      <div className="overflow-scroll">
+        <ItemsList items={items} creationDate={creationDate} />
+      </div>
+      <div className="mb8">
         <Divider orientation="horizontal" />
       </div>
       <div className="w-100">
@@ -124,7 +131,7 @@ export const ReturnDetails = (
       <PaymentMethods canRefundCard={canRefundCard} />
       <TermsAndConditions />
       <div className="flex justify-center mt6">
-        <Button onClick={handleFieldsValidation} size="small">
+        <Button onClick={handleFieldsValidation} block={phone}>
           <FormattedMessage id="store/return-app.return-order-details.button.next" />
         </Button>
       </div>

--- a/react/store/createReturnRequest/components/ReturnInformationTable.tsx
+++ b/react/store/createReturnRequest/components/ReturnInformationTable.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 import type { ReturnRequestItemInput } from 'vtex.return-app'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { defaultReturnConditionsMessages } from '../../../common/utils/defaultReturnConditionsMessages'
 
@@ -23,6 +24,10 @@ const CSS_HANDLES = [
 export const ReturnInformationTable = ({ items, selectedItems }: Props) => {
   const { formatMessage } = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
+
+  const {
+    hints: { phone },
+  } = useRuntime()
 
   return (
     <table className={`${handles.returnInfoTableContainer} w-100`}>
@@ -58,8 +63,8 @@ export const ReturnInformationTable = ({ items, selectedItems }: Props) => {
                 key={key}
                 className={`${handles.returnInfoTrBodyWrapper} ph5`}
               >
-                <td className="w-50 pv5">
-                  <div className="flex items-center ml2">
+                <td className={`pv5 ${phone ? 'w-80' : 'w-50'}`}>
+                  <div className="flex items-center">
                     <div className={`${handles.returnInfoBodyImgWrapper} mr3`}>
                       <img src={imageUrl} alt="Product" />
                     </div>
@@ -92,7 +97,7 @@ export const ReturnInformationTable = ({ items, selectedItems }: Props) => {
                     </div>
                   </div>
                 </td>
-                <td className="w-50 tc pv5">
+                <td className={`tc pv5 ${phone ? 'w-20' : 'w-50'}`}>
                   <p>{quantity}</p>
                 </td>
               </tr>

--- a/react/styles.global.css
+++ b/react/styles.global.css
@@ -42,3 +42,11 @@ ul.status {
 div.timeline:last-of-type ul.last-of {
   background-image: none;
 } 
+
+.returnDetailContainer .vtex-pageHeader__container {
+  padding: 0 0 2rem 0;
+}
+
+.returnDetailContainer .styleguide__box {
+  padding: 1rem;
+}

--- a/react/styles.global.css
+++ b/react/styles.global.css
@@ -41,12 +41,28 @@ ul.status {
 
 div.timeline:last-of-type ul.last-of {
   background-image: none;
-} 
+}
 
-.returnDetailContainer .vtex-pageHeader__container {
+.return-itemsList-body tr {
+  border-bottom: 1px solid #e3e4e6;
+}
+
+.return-itemsList-body tr:last-child {
+  border-bottom: none;
+}
+
+.createReturnRequestContainer .vtex-pageHeader__container {
   padding: 0 0 2rem 0;
 }
 
-.returnDetailContainer .styleguide__box {
-  padding: 1rem;
+/* Based on https://github.com/vtex-apps/render-runtime/blob/ed5640d59e023f6cfa743b5aa58b654035b870cb/react/utils/withDevice.tsx#L29 */
+@media screen and (max-width: 639px) {
+  .returnDetailContainer .vtex-pageHeader__container {
+    padding: 0 0 2rem 0;
+  }
+
+  .returnDetailContainer .styleguide__box,
+  .createReturnRequestContainer .styleguide__box {
+    padding: 1rem;
+  }
 }

--- a/react/styles.global.css
+++ b/react/styles.global.css
@@ -51,18 +51,18 @@ div.timeline:last-of-type ul.last-of {
   border-bottom: none;
 }
 
-.createReturnRequestContainer .vtex-pageHeader__container {
+.create-return-request__container .vtex-pageHeader__container {
   padding: 0 0 2rem 0;
 }
 
 /* Based on https://github.com/vtex-apps/render-runtime/blob/ed5640d59e023f6cfa743b5aa58b654035b870cb/react/utils/withDevice.tsx#L29 */
 @media screen and (max-width: 639px) {
-  .returnDetailContainer .vtex-pageHeader__container {
+  .return-detail__container .vtex-pageHeader__container {
     padding: 0 0 2rem 0;
   }
 
-  .returnDetailContainer .styleguide__box,
-  .createReturnRequestContainer .styleguide__box {
+  .return-detail__container .styleguide__box,
+  .create-return-request__container .styleguide__box {
     padding: 1rem;
   }
 }


### PR DESCRIPTION
### What problem is this solving?

Adjusted all pages for better UI/UX under 639px (phone)

### How to test it?

[Workspace](https://sanzmobile--powerplanet.myvtex.com/)

### Screenshots or example usage:

#### Returns list
- Removed both filters and jump to page
- Page header now has a consistent padding
<img width="290" alt="" src="https://user-images.githubusercontent.com/50715158/185088826-1bb7c6da-633b-4eb2-b332-a19a8e271606.png">

#### Return detail
- Page header now has a consistent padding
- Table rows now have consistent widths
<img width="290" alt="" src="https://user-images.githubusercontent.com/50715158/185089352-12e2d187-07f6-46c9-a484-e81d24c1c361.png">

#### Orders list
- CTAs are now more accesible to the user
<img width="290" alt="" src="https://user-images.githubusercontent.com/50715158/185089607-a065488e-addc-49bc-970d-8ac31d0b2f7f.png">

#### Create return request
- Table doesn't overflow anymore
- Table actions are now more accesible to the user
<img width="290" alt="" src="https://user-images.githubusercontent.com/50715158/185089879-badcc4e4-f0a1-43e3-842a-f96561306860.png">

#### Confirm and submit
- Card containing summary now has consistent widths
- CTAs are now more accesible to the user
<img width="290" alt="" src="https://user-images.githubusercontent.com/50715158/185090052-3d28d47b-b4d0-4380-873c-5ee1663694e8.png">

