### PR TITLE
feat: add IBAN validation to backend

### DIFF
--- a/node/utils/isValidIBANNumber.ts
+++ b/node/utils/isValidIBANNumber.ts
@@ -1,0 +1,116 @@
+function mod97(string: string) {
+  let checksum = string.slice(0, 2) as string | number
+  let fragment
+
+  for (let offset = 2; offset < string.length; offset += 7) {
+    fragment = `${String(checksum)}${string.substring(offset, offset + 7)}`
+    checksum = parseInt(fragment, 10) % 97
+  }
+
+  return checksum
+}
+
+export function isValidIBANNumber(input: string) {
+  type CodeLengths = {
+    [key: string]: number
+  }
+
+  const CODE_LENGTHS: CodeLengths = {
+    AD: 24,
+    AE: 23,
+    AT: 20,
+    AZ: 28,
+    BA: 20,
+    BE: 16,
+    BG: 22,
+    BH: 22,
+    BR: 29,
+    CH: 21,
+    CR: 21,
+    CY: 28,
+    CZ: 24,
+    DE: 22,
+    DK: 18,
+    DO: 28,
+    EE: 20,
+    ES: 24,
+    FI: 18,
+    FO: 18,
+    FR: 27,
+    GB: 22,
+    GI: 23,
+    GL: 18,
+    GR: 27,
+    GT: 28,
+    HR: 21,
+    HU: 28,
+    IE: 22,
+    IL: 23,
+    IS: 26,
+    IT: 27,
+    JO: 30,
+    KW: 30,
+    KZ: 20,
+    LB: 28,
+    LI: 21,
+    LT: 20,
+    LU: 20,
+    LV: 21,
+    MC: 27,
+    MD: 24,
+    ME: 22,
+    MK: 19,
+    MR: 27,
+    MT: 31,
+    MU: 30,
+    NL: 18,
+    NO: 15,
+    PK: 24,
+    PL: 28,
+    PS: 29,
+    PT: 25,
+    QA: 29,
+    RO: 24,
+    RS: 22,
+    SA: 24,
+    SE: 24,
+    SI: 19,
+    SK: 24,
+    SM: 27,
+    TN: 24,
+    TR: 26,
+    AL: 28,
+    BY: 28,
+    EG: 29,
+    GE: 22,
+    IQ: 23,
+    LC: 32,
+    SC: 31,
+    ST: 25,
+    SV: 28,
+    TL: 23,
+    UA: 29,
+    VA: 22,
+    VG: 24,
+    XK: 20,
+  }
+
+  const iban = String(input)
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+
+  const code = iban.match(/^([A-Z]{2})(\d{2})([A-Z\d]+)$/)
+
+  if (!code || iban.length !== CODE_LENGTHS[code[1]]) {
+    return false
+  }
+
+  const dig = code[3] + code[1] + code[2]
+  const digits = dig.replace(/[A-Z]/g, (letter) => {
+    const returnVar = letter.charCodeAt(0) - 55
+
+    return returnVar.toString()
+  })
+
+  return mod97(digits)
+}

--- a/node/utils/isValidIBANNumber.ts
+++ b/node/utils/isValidIBANNumber.ts
@@ -113,5 +113,5 @@ export function isValidIBANNumber(input: string) {
   })
 
   // If the IBAN is correct the result should be 1 if not any number higher than 1.
-  return mod97(digits)
+  return mod97(digits) === 1
 }

--- a/node/utils/isValidIBANNumber.ts
+++ b/node/utils/isValidIBANNumber.ts
@@ -112,5 +112,6 @@ export function isValidIBANNumber(input: string) {
     return returnVar.toString()
   })
 
+  // If the IBAN is correct the result should be 1 if not any number higher than 1.
   return mod97(digits)
 }

--- a/node/utils/validatePaymentMethod.ts
+++ b/node/utils/validatePaymentMethod.ts
@@ -1,6 +1,8 @@
 import type { RefundPaymentDataInput, PaymentOptions } from 'vtex.return-app'
 import { ResolverError } from '@vtex/api'
 
+import { isValidIBANNumber } from './isValidIBANNumber'
+
 export const validatePaymentMethod = (
   refundPaymentData: RefundPaymentDataInput,
   paymentSettings: PaymentOptions
@@ -44,6 +46,7 @@ export const validatePaymentMethod = (
     )
   }
 
+  // eslint-disable-next-line vtex/prefer-early-return
   if (refundPaymentMethod === 'bank') {
     if (!iban) {
       throw new ResolverError('IBAN is required', 400)
@@ -51,6 +54,10 @@ export const validatePaymentMethod = (
 
     if (!accountHolderName) {
       throw new ResolverError('Account holder name is required', 400)
+    }
+
+    if (!isValidIBANNumber(iban)) {
+      throw new ResolverError('IBAN is not valid', 400)
     }
   }
 }

--- a/node/utils/validatePaymentMethod.ts
+++ b/node/utils/validatePaymentMethod.ts
@@ -56,7 +56,7 @@ export const validatePaymentMethod = (
       throw new ResolverError('Account holder name is required', 400)
     }
 
-    if (isValidIBANNumber(iban) !== 1) {
+    if (!isValidIBANNumber(iban)) {
       throw new ResolverError('IBAN is not valid', 400)
     }
   }

--- a/node/utils/validatePaymentMethod.ts
+++ b/node/utils/validatePaymentMethod.ts
@@ -56,7 +56,7 @@ export const validatePaymentMethod = (
       throw new ResolverError('Account holder name is required', 400)
     }
 
-    if (!isValidIBANNumber(iban)) {
+    if (isValidIBANNumber(iban) !== 1) {
       throw new ResolverError('IBAN is not valid', 400)
     }
   }


### PR DESCRIPTION
#### What problem is this solving?

Add Backend IBAN validation

#### How to test it?

Place a random IBAN it should trigger the apollo graphql error.
[Workspace](https://backend--vtexspain.myvtex.com/account#/my-returns/add)

Note: I placed a prefer-early-return flag to avoid esLint warning. Do you think there is a better way? 
```
// eslint-disable-next-line vtex/prefer-early-return
  if (refundPaymentMethod === 'bank') {
    if (!iban) {
      throw new ResolverError('IBAN is required', 400)
    }

    if (!accountHolderName) {
      throw new ResolverError('Account holder name is required', 400)
    }

    if (!isValidIBANNumber(iban)) {
      throw new ResolverError('IBAN is not valid', 400)
    }
  }
```