### PR TITLE
feat: remove iban and name when payment method diff bank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Remove IBAN and accountHolderNumber if refund method different than bank
+
 ## [3.4.1] - 2022-08-18
+
 ### Fixed
 
 - My account mobile inconsistencies
 - Dynamic messages declared statically
 
 ## [3.4.0] - 2022-08-17
+
 ### Fixed
+
 - Prevent order list and order details paegs to show negative numbers for available items.
 - Avoid having a minus sign when restock fee is 0.
 - English translations.
@@ -26,8 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Bulgarian, Dutch, French, Italian, Portuguese, Romanian, Spanish and Thai translations.
-
-
 
 ## [3.3.0] - 2022-08-11
 

--- a/node/package.json
+++ b/node/package.json
@@ -23,7 +23,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.3.0/public/@types/vtex.return-app",
+    "vtex.return-app": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.4.1/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.155.32/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/node/services/createReturnRequestService.ts
+++ b/node/services/createReturnRequestService.ts
@@ -214,6 +214,14 @@ export const createReturnRequestService = async (
 
   const { refundPaymentMethod } = refundPaymentData
 
+  const { iban, accountHolderName, ...refundPaymentMethodSubset } =
+    refundPaymentData
+
+  const refundPaymentDataResult =
+    refundPaymentMethod === 'bank'
+      ? refundPaymentData
+      : refundPaymentMethodSubset
+
   const { automaticallyRefundPaymentMethod } = paymentOptions
 
   const createInvoiceTypeInput =
@@ -238,7 +246,7 @@ export const createReturnRequestService = async (
       },
       pickupReturnData,
       refundPaymentData: {
-        ...refundPaymentData,
+        ...refundPaymentDataResult,
         automaticallyRefundPaymentMethod: createInvoiceTypeInput,
       },
       items: itemsToReturn,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6155,9 +6155,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.3.0/public/@types/vtex.return-app":
-  version "3.3.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.3.0/public/@types/vtex.return-app#8be1007aecefc0a07c08ea00e49391f309a69202"
+"vtex.return-app@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.4.1/public/@types/vtex.return-app":
+  version "3.4.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.4.1/public/@types/vtex.return-app#3ec50e68b1da9e99870e468775be93af77497e3e"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.155.32/public/@types/vtex.store-graphql":
   version "2.155.32"

--- a/react/package.json
+++ b/react/package.json
@@ -33,7 +33,7 @@
     "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
     "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
-    "vtex.return-app": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.3.0/public/@types/vtex.return-app",
+    "vtex.return-app": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.4.1/public/@types/vtex.return-app",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.155.32/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5206,9 +5206,9 @@ verror@1.10.0:
   version "8.132.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.return-app@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.3.0/public/@types/vtex.return-app":
-  version "3.3.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.3.0/public/@types/vtex.return-app#8be1007aecefc0a07c08ea00e49391f309a69202"
+"vtex.return-app@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.4.1/public/@types/vtex.return-app":
+  version "3.4.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.return-app@3.4.1/public/@types/vtex.return-app#3ec50e68b1da9e99870e468775be93af77497e3e"
 
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.155.32/public/@types/vtex.store-graphql":
   version "2.155.32"


### PR DESCRIPTION
#### What problem is this solving?
Remove IBAN and accountHolderNumber if refund method different than bank [Back end]

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://bankrefundmethod--vtexspain.myvtex.com/admin/graphql-ide)

Create a return via graphQL and then look at the request with the ID. If the payment method is different than bank it shouldn't have the accountHolderName and the iban.

```
mutation createReturnRequest($returnRequest: ReturnRequestInput!) {
    createReturnRequest(returnRequest: $returnRequest) {
      returnRequestId
    }
  }
```

```
{
  "returnRequest": {"items": [{
        "orderItemIndex": 0,
        "quantity": 1,
        "returnReason": {
            "reason": "Wrong type"
        },
        "condition": "newWithBox"
    }],
    "orderId": "1250972984721-01",
    "refundPaymentData": {
        "refundPaymentMethod": "giftCard",
      	"accountHolderName": "Testing guy",
        "iban": "DE3242545"
    },
    "pickupReturnData": {
        "addressId":"",
        "addressType": "CUSTOMER_ADDRESS",
        "address": "Rua Haddock Lobo",
        "city": "São Paulo",
        "state": "SP",
        "country": "Br",
        "zipCode": "01403003"
    },
    "customerProfileData": {
        "name": "Filadelfo Braz",
        "email": "filadelfo.braz+test@gmail.com",
        "phoneNumber": "123432122"
    },
    "userComment": "This is a test from API",
    "locale": "pt-PT"
  }
}
```
