### PR TITLE
[Fix] Allow return request for items with undefined refId's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Default `refId` to an empty string when the value coming from the order is falsy.
 
 ## [3.5.1] - 2022-09-12
 ### Fixed

--- a/node/utils/createItemsToReturn.ts
+++ b/node/utils/createItemsToReturn.ts
@@ -102,7 +102,7 @@ export const createItemsToReturn = async ({
         imageUrl: productImage,
         unitMultiplier,
         sellerId: seller,
-        refId,
+        refId: refId ?? '',
         productId,
         sellerName,
         condition: item.condition ? item.condition : 'unspecified',

--- a/react/common/components/ReturnDetails/ItemDetails/itemDetailsSchema.tsx
+++ b/react/common/components/ReturnDetails/ItemDetails/itemDetailsSchema.tsx
@@ -61,15 +61,17 @@ export const itemDetailsSchema = ({
             <div className="mv2 flex flex-column">
               <ItemName name={cellData} localizedName={localizedName} />
             </div>
-            <div className="mv2">
-              <FormattedMessage
-                id="return-app.return-request-details.table.product-info.ref-id"
-                values={{
-                  refId,
-                  b: StrongChunk,
-                }}
-              />
-            </div>
+            {!refId ? null : (
+              <div className="mv2">
+                <FormattedMessage
+                  id="return-app.return-request-details.table.product-info.ref-id"
+                  values={{
+                    refId,
+                    b: StrongChunk,
+                  }}
+                />
+              </div>
+            )}
             <div className="mv2">
               <FormattedMessage
                 id="return-app.return-request-details.table.product-info.reason"


### PR DESCRIPTION
#### What problem is this solving?
The `refId` is a non required field in the catalog, but the schema for the return asks for it. Requests for items missing it were failing.

#### Screenshots or example usage:

Request created with an item that doesn't have `refId` (Powerplanet, product: 47211):
<img width="1183" alt="Screen Shot 2022-09-20 at 3 12 03 PM" src="https://user-images.githubusercontent.com/38737958/191332952-5aa0f7b4-0ea7-4bb1-9294-f846144a108e.png">

#### Describe alternatives you've considered, if any.
I considered changing the master data schema and the graphql type for the returned items, making it non required and nullable, respectively. However, changing the graphql type from `String!` to `String` requires a new major. The implementation suggested here avoids that.
