### PR TITLE
Fix/pickup point address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow creation of a return for orders placed with a ` PICKUP_POINT` as customer address.
 
 ## [3.5.4] - 2022-11-07
 ### Fixed

--- a/react/store/utils/setInitialPickupAddress.ts
+++ b/react/store/utils/setInitialPickupAddress.ts
@@ -16,7 +16,7 @@ export const setInitialPickupAddress = (
    * This way, if the store doesn't accept pickup orders, user has to enter an address manually.
    */
   return {
-    addressId: '',
+    addressId: 'N/A', // This field is not needed or used anywhere else, but it was marked as required in the schema.
     address: '',
     city: '',
     state: '',


### PR DESCRIPTION
#### What problem is this solving?

An order placed to be shipped to a pickup point could not be returned. It was due to the initial setting for the state in the front end for this type of orders where creating a shallow address without `address.id`. When validating the form in the front end, this field was throwing an silent error. The code changes the way the state for address is initiated. The `address.id` is not a useful field, but removing it at this point could cause problems on the schema.

#### How to test it?

The code is linked to [this workspace](https://filareturnapp--canali.myvtex.com/). To test it, one needs to place an order with a pickup point, then return it. It has been already tested - check it [here](https://vtex.slack.com/archives/CS10JAY03/p1668099731417819?thread_ts=1666716723.020029&cid=CS10JAY03). 


