### PR TITLE
Adds "disableTaxRefund" option

### DIFF
--- a/graphql/types/ReturnAppSettings.graphql
+++ b/graphql/types/ReturnAppSettings.graphql
@@ -1,4 +1,5 @@
 type ReturnAppSettings {
+  disableTaxRefund: Boolean
   maxDays: Int!
   excludedCategories: [String!]!
   paymentOptions: PaymentOptions!
@@ -35,6 +36,7 @@ type ReturnOption {
   enablePickupPoints: Boolean
   enableProportionalShippingValue: Boolean
   enableSelectItemCondition: Boolean
+  disableTaxRefund: Boolean
 }
 
 input ReturnAppSettingsInput {
@@ -74,4 +76,5 @@ input ReturnOptionInput {
   enablePickupPoints: Boolean
   enableProportionalShippingValue: Boolean
   enableSelectItemCondition: Boolean
+  disableTaxRefund: Boolean
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -25,6 +25,8 @@
   "admin/return-app.settings.section.general-options.enable-proportional-shipping-value.description": "Calculate proportional shipping value for every item returned",
   "admin/return-app.settings.section.general-options.enable-select-item-condition.label": "Toogle label for enabling item condition select",
   "admin/return-app.settings.section.general-options.enable-select-item-condition.description": "Toogle description for enabling item condition select",
+  "admin/return-app.settings.section.general-options.disable-tax-refund.label": "Disable tax refund",
+  "admin/return-app.settings.section.general-options.disable-tax-refund.description": "When marked, the tax will not be refunded",
   "admin/return-app.settings.section-excluded-categories.fetch-data-error": "Error loading categories",
   "admin/return-app.settings.save.button": "Save settings",
   "admin/return-app.settings.section.custom-reasons.empty-custom-reasons": "No options recorded",

--- a/messages/en.json
+++ b/messages/en.json
@@ -25,6 +25,8 @@
   "admin/return-app.settings.section.general-options.enable-proportional-shipping-value.description": "Calculate proportional shipping for every returned item",
   "admin/return-app.settings.section.general-options.enable-select-item-condition.label": "Enable the \"Item condition\" selector",
   "admin/return-app.settings.section.general-options.enable-select-item-condition.description": "When enabled, the user will be required to select each item's condition",
+  "admin/return-app.settings.section.general-options.disable-tax-refund.label": "Disable tax refund",
+  "admin/return-app.settings.section.general-options.disable-tax-refund.description": "When marked, the tax will not be refunded",
   "admin/return-app.settings.section-excluded-categories.fetch-data-error": "Error loading categories",
   "admin/return-app.settings.save.button": "Save Settings",
   "admin/return-app.settings.section.custom-reasons.empty-custom-reasons": "No options added",

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -10,7 +10,10 @@ import Checkout from './checkout'
 import { VtexId } from './vtexId'
 import { CatalogGQL } from './catalogGQL'
 
-const ReturnAppSettings = vbaseFor<string, ReturnAppSettings>('appSettings')
+const ReturnAppSettings = vbaseFor<string, ReturnAppSettingsCustom>(
+  'appSettings'
+)
+
 const ReturnRequest = masterDataFor<ReturnRequest>('returnRequest')
 
 export class Clients extends IOClients {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@vtex/api": "6.45.12",
+    "@vtex/api": "6.45.13",
     "@vtex/clients": "^2.13.0",
     "co-body": "^6.0.0",
     "graphql": "^14.0.0",
@@ -11,7 +11,7 @@
     "@types/co-body": "^0.0.3",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
-    "@vtex/api": "6.45.12",
+    "@vtex/api": "6.45.13",
     "@vtex/test-tools": "^1.0.0",
     "@vtex/tsconfig": "^0.6.0",
     "tslint": "^6.1.3",

--- a/node/services/updateRequestStatusService.ts
+++ b/node/services/updateRequestStatusService.ts
@@ -97,6 +97,7 @@ export const updateRequestStatusService = async (
       oms,
       giftCard: giftCardClient,
       mail,
+      appSettings,
     },
     vtex: { logger },
   } = ctx
@@ -180,6 +181,7 @@ export const updateRequestStatusService = async (
           refundData,
           requestItems: returnRequest.items,
           refundableShipping: maxRefundableShipping,
+          appSettings,
         })
       : returnRequest.refundData
 

--- a/node/typings/vtex.return-app.d.ts
+++ b/node/typings/vtex.return-app.d.ts
@@ -37,3 +37,11 @@ interface AuthenticationSession {
     value: string
   }
 }
+
+type ReturnAppSettingsCustom = ReturnAppSettings & {
+  options: ReturnOptionCustom
+}
+
+type ReturnOptionCustom = ReturnOption & {
+  disableTaxRefund?: boolean
+}

--- a/node/utils/createRefundData.ts
+++ b/node/utils/createRefundData.ts
@@ -6,11 +6,13 @@ export const createRefundData = ({
   refundData,
   requestItems,
   refundableShipping,
+  appSettings,
 }: {
   requestId: string
   refundData?: Maybe<RefundDataInput>
   requestItems: ReturnRequest['items']
   refundableShipping: number
+  appSettings: ReturnAppSettingsCustom
 }): ReturnRequest['refundData'] => {
   const requestItemsMap = new Map<number, ReturnRequest['items'][number]>()
 
@@ -47,7 +49,9 @@ export const createRefundData = ({
     items.push({
       orderItemIndex,
       id,
-      price: (Number(sellingPrice) ?? 0) + (Number(tax) ?? 0),
+      price: appSettings.options.disableTaxRefund
+        ? Number(sellingPrice) ?? 0
+        : (Number(sellingPrice) ?? 0) + (Number(tax) ?? 0),
       quantity: refundItem.quantity,
       restockFee: refundItem.restockFee,
     })

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1528,10 +1528,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/api@6.45.12":
-  version "6.45.12"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
-  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
+"@vtex/api@6.45.13":
+  version "6.45.13"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.13.tgz#836c392fa9567009e34559f08698f6efc95e88cc"
+  integrity sha512-P22/ObNdsgLvagetcDrovFfSXHe8Jb4yHud4U0rXHfIYEIMSnEdQ/QHujF3CEa5AiZnvbR/5W5ynGtWHYHOv9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5610,7 +5610,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/admin/settings/components/GeneralOptions.tsx
+++ b/react/admin/settings/components/GeneralOptions.tsx
@@ -10,6 +10,7 @@ const generalOptions = [
   'enablePickupPoints',
   'enableProportionalShippingValue',
   'enableSelectItemCondition',
+  'disableTaxRefund',
 ] as const
 
 const messages = defineMessages({
@@ -36,6 +37,12 @@ const messages = defineMessages({
   },
   'enableSelectItemCondition-description': {
     id: 'admin/return-app.settings.section.general-options.enable-select-item-condition.description',
+  },
+  'disableTaxRefund-label': {
+    id: 'admin/return-app.settings.section.general-options.disable-tax-refund.label',
+  },
+  'disableTaxRefund-description': {
+    id: 'admin/return-app.settings.section.general-options.disable-tax-refund.description',
   },
 })
 

--- a/react/admin/settings/graphql/getAppSettings.gql
+++ b/react/admin/settings/graphql/getAppSettings.gql
@@ -25,6 +25,7 @@ query returnAppSettings {
       enablePickupPoints
       enableProportionalShippingValue
       enableSelectItemCondition
+      disableTaxRefund
     }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?
Adds an option in the admin panel so that the tax is not refunded together with the value of the purchase.

#### How to test it?

1. Access the workspace
2. Go to General options
3. Mark Disable Tax Refund option
4. Try to do a refund and check if the tax was refunded together with the value of the purchase

[Workspace](https://returnsfix--canali.myvtex.com/admin/returns/settings)

#### Screenshots or example usage:

<img width="951" alt="Screenshot 2023-01-16 at 23 43 40" src="https://user-images.githubusercontent.com/17356081/212812314-ec3106cc-fbcf-4eb6-b5f0-d10ac667b2e2.png">