### PR TITLE
Fix List Orders permission error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -75,6 +75,9 @@
       "name": "OMSViewer"
     },
     {
+      "name": "ListOrders"
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "api.vtex.com",

--- a/node/clients/returnapp.ts
+++ b/node/clients/returnapp.ts
@@ -43,6 +43,7 @@ export default class ReturnApp extends ExternalClient {
   }
 
   public async getOrders(ctx: any, where: any): Promise<any> {
+
     return this.http.get(
       `http://${ctx.vtex.account}.vtexcommercestable.com.br/api/oms/pvt/orders?${where}`,
       {

--- a/node/clients/returnapp.ts
+++ b/node/clients/returnapp.ts
@@ -43,7 +43,6 @@ export default class ReturnApp extends ExternalClient {
   }
 
   public async getOrders(ctx: any, where: any): Promise<any> {
-
     return this.http.get(
       `http://${ctx.vtex.account}.vtexcommercestable.com.br/api/oms/pvt/orders?${where}`,
       {

--- a/node/package.json
+++ b/node/package.json
@@ -3,7 +3,7 @@
     "axios": "^0.20.0",
     "co-body": "^6.0.0",
     "ramda": "^0.25.0",
-    "@vtex/api": "6.45.12",
+    "@vtex/api": "6.45.15",
     "@vtex/clients": "^2.13.0"
   },
   "devDependencies": {
@@ -11,7 +11,7 @@
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.12",
+    "@vtex/api": "6.45.15",
     "@vtex/test-tools": "^1.0.0",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1532,10 +1532,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/api@6.45.12":
-  version "6.45.12"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
-  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
+"@vtex/api@6.45.15":
+  version "6.45.15"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.15.tgz#aa987d22f7df16ce2861130deda6ffd63156817b"
+  integrity sha512-Rg1VGDzJ4hHUNp1vSidMdGGPojr1PikMTptlZsJ3oNZVdEo4cPx2l8ZcAEwHWORL7QjPjXaEgmeA5ZOSf+boCQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5539,7 +5539,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Recently, the Order Management system for VTEX changed their permissions system. Before it was possible to use the `OMSViewer` policy in the `manifest.json` file to list orders, now you need the `ListOrders` policy for that.

This caused some services in the Returns App to fail with a "Not found message"

#### How to test it?

Open the workspace and see data returned as expected

[Workspace](https://fixlistorders--yamamay.myvtex.com/returns/getOrders/clientEmail=francisco.benitez@vtex.com.br)

#### Screenshots or example usage:

##### BEFORE

<img width="1440" alt="Screen Shot 2023-02-02 at 13 53 53" src="https://user-images.githubusercontent.com/2094877/216390192-7ec24b9e-1594-4c86-8508-1f05e11aa28e.png">

##### AFTER

<img width="1440" alt="Screen Shot 2023-02-02 at 13 53 59" src="https://user-images.githubusercontent.com/2094877/216390000-8ecf1878-0151-4513-b091-6f6ccc768567.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/a0h7sAqON67nO/giphy.gif)
