### PR TITLE
Changing Taxes to Surcharges to better reflect actual functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- English translation (changing Tax to Surcharge to better reflect actual functionality).
+
 ## [3.10.2] - 2024-04-25
 
 ## [3.10.1] - 2023-06-28

--- a/messages/en.json
+++ b/messages/en.json
@@ -201,7 +201,7 @@
   "admin/return-app.return-request-details.verify-items.modal.button-deny": "Deny",
   "admin/return-app.return-request-details.verify-items.table.header.product": "Product",
   "admin/return-app.return-request-details.verify-items.table.header.price": "Price",
-  "admin/return-app.return-request-details.verify-items.table.header.tax": "Tax",
+  "admin/return-app.return-request-details.verify-items.table.header.tax": "Surcharge",
   "admin/return-app.return-request-details.verify-items.table.header.total": "Total",
   "admin/return-app.return-request-details.verify-items.table.header.quantity": "Quantity",
   "admin/return-app.return-request-details.verify-items.table.header.verified": "Verified",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Tracked in task [LOC-11675](https://vtex-dev.atlassian.net/browse/LOC-11675). Following a [discussion with the Pricing and Promotions team](https://vtex.slack.com/archives/C01S0AXKJ5U/p1713970025219179?thread_ts=1706699622.909209&cid=C01S0AXKJ5U), we agreed upon a terminology update, changing "tax"to "surcharge" when the string does not specifically refer to government taxes, but to any surcharge our clients might want to add to a product.

[LOC-11675]: https://vtex-dev.atlassian.net/browse/LOC-11675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ